### PR TITLE
Make HTTP consumer concurrent, make it configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ object ExampleBatching extends IOApp {
   )
 
   override def run(args: List[String]): IO[ExitCode] = {
-    val mkProducer = AsyncBatchingHttpPubsubProducer.resource[IO, ExampleObject](
+    val mkProducer = BatchingHttpPubsubProducer.resource[IO, ExampleObject](
       projectId = Model.ProjectId("test-project"),
       topic = Model.Topic("example-topic"),
       googleServiceAccountPath = "/path/to/service/account",
@@ -295,12 +295,12 @@ object ExampleBatching extends IOApp {
       .use { producer =>
         val value = producer.produceAsync(
           record = ExampleObject("1f9774be-9d7c-4dd9-8d97-855b681938a9", "example.com"),
-          callback = Logger[IO].info("Message published!")
+          callback = Logger[IO].debug("Message was sent!")
         )
 
         value >> value >> value >> IO.never
       }
-      .map(_ => ExitCode.Success)
+      .as(ExitCode.Success)
   }
 }
 ```

--- a/build.sc
+++ b/build.sc
@@ -2,6 +2,42 @@ import mill._
 import mill.scalalib._
 import mill.scalalib.publish._
 
+object Dependencies {
+  object version {
+    val catsCore = "1.5.0"
+    val effect   = "1.2.0"
+    val fs2      = "1.0.3"
+    val http4s   = "0.20.0-M5"
+    val log4cats = "0.2.0"
+    val jwt      = "3.7.0"
+    val jsoniter = "0.39.0"
+    val gcp      = "1.61.0"
+
+    val scalatest = "3.0.4"
+  }
+
+  object libraries {
+    val catsCore       = ivy"org.typelevel::cats-core:${version.catsCore}"
+    val effect         = ivy"org.typelevel::cats-effect:${version.effect}"
+    val fs2            = ivy"co.fs2::fs2-core:${version.fs2}"
+
+    val http4sDsl      = ivy"org.http4s::http4s-dsl:${version.http4s}"
+    val http4sClient   = ivy"org.http4s::http4s-client:${version.http4s}"
+    val http4sHttp     = ivy"org.http4s::http4s-okhttp-client:${version.http4s}"
+
+    val log4cats       = ivy"io.chrisdavenport::log4cats-core:${version.log4cats}"
+    val log4catsSlf4j  = ivy"io.chrisdavenport::log4cats-slf4j:${version.log4cats}"
+
+    val jwt            = ivy"com.auth0:java-jwt:${version.jwt}"
+    val gcp            = ivy"com.google.cloud:google-cloud-pubsub:${version.gcp}"
+
+    val jsoniterCore   = ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:${version.jsoniter}"
+    val jsoniterMacros = ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:${version.jsoniter}"
+
+    val scalatest      = ivy"org.scalatest::scalatest:${version.scalatest}"
+  }
+}
+
 trait CommonModule extends SbtModule with PublishModule {
   def scalaVersion = "2.12.8"
   def publishVersion = "0.6.8-SNAPSHOT"
@@ -18,25 +54,25 @@ trait CommonModule extends SbtModule with PublishModule {
   )
 
   def commonDependencies = Agg(
-    ivy"org.typelevel::cats-core:1.5.0",
-    ivy"org.typelevel::cats-effect:1.2.0",
-    ivy"co.fs2::fs2-core:1.0.3",
+    Dependencies.libraries.catsCore,
+    Dependencies.libraries.effect,
+    Dependencies.libraries.fs2,
   )
 
   def httpDependencies = Agg(
-    ivy"org.http4s::http4s-dsl:0.20.0-M5",
-    ivy"org.http4s::http4s-client:0.20.0-M5",
-    ivy"io.chrisdavenport::log4cats-core:0.2.0",
-    ivy"com.auth0:java-jwt:3.7.0",
-    ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:0.39.0",
+    Dependencies.libraries.http4sDsl,
+    Dependencies.libraries.http4sClient,
+    Dependencies.libraries.log4cats,
+    Dependencies.libraries.jwt,
+    Dependencies.libraries.jsoniterCore,
   )
 
   def grpcDependencies = Agg(
-    ivy"com.google.cloud:google-cloud-pubsub:1.61.0",
+    Dependencies.libraries.gcp,
   )
 
   def httpCompileDependencies = Agg(
-    ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:0.39.0",
+    Dependencies.libraries.jsoniterMacros,
   )
 
   override def scalacOptions = List(
@@ -85,6 +121,20 @@ object `fs2-google-pubsub-http` extends CommonModule {
   override def moduleDeps = List(`fs2-google-pubsub`)
   override def ivyDeps = commonDependencies ++ httpDependencies
   override def compileIvyDeps = httpCompileDependencies
+
+  object test extends Tests {
+    override def ivyDeps = Agg(
+      Dependencies.libraries.scalatest,
+      Dependencies.libraries.http4sHttp,
+      Dependencies.libraries.log4catsSlf4j,
+    )
+
+    override def compileIvyDeps = Agg(
+      Dependencies.libraries.jsoniterMacros,
+    )
+
+    override def testFrameworks = Seq("org.scalatest.tools.Framework")
+  }
 }
 
 object `fs2-google-pubsub-grpc` extends CommonModule {

--- a/build.sc
+++ b/build.sc
@@ -26,8 +26,8 @@ trait CommonModule extends SbtModule with PublishModule {
   def httpDependencies = Agg(
     ivy"org.http4s::http4s-dsl:0.20.0-M5",
     ivy"org.http4s::http4s-client:0.20.0-M5",
-    ivy"com.auth0:java-jwt:3.6.0",
-    ivy"io.chrisdavenport::log4cats-slf4j:0.2.0",
+    ivy"io.chrisdavenport::log4cats-core:0.2.0",
+    ivy"com.auth0:java-jwt:3.7.0",
     ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:0.39.0",
   )
 

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubHttpConsumer.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubHttpConsumer.scala
@@ -9,6 +9,7 @@ import com.permutive.pubsub.consumer.Model.{ProjectId, Subscription}
 import com.permutive.pubsub.consumer.decoder.MessageDecoder
 import com.permutive.pubsub.consumer.http.internal.PubsubSubscriber
 import fs2.Stream
+import io.chrisdavenport.log4cats.Logger
 import org.http4s.client.Client
 
 object PubsubHttpConsumer {
@@ -20,7 +21,7 @@ object PubsubHttpConsumer {
     * @param serviceAccountPath path to the Google Service account file (json)
     * @param errorHandler       upon failure to decode, an exception is thrown. Allows acknowledging the message.
     */
-  final def subscribe[F[_] : Concurrent : Timer, A: MessageDecoder](
+  final def subscribe[F[_] : Concurrent : Timer : Logger, A: MessageDecoder](
     projectId: ProjectId,
     subscription: Subscription,
     serviceAccountPath: String,
@@ -47,7 +48,7 @@ object PubsubHttpConsumer {
     * @param serviceAccountPath path to the Google Service account file (json)
     * @param errorHandler       upon failure to decode, an exception is thrown. Allows acknowledging the message.
     */
-  final def subscribeAndAck[F[_] : Concurrent : Timer, A: MessageDecoder](
+  final def subscribeAndAck[F[_] : Concurrent : Timer : Logger, A: MessageDecoder](
     projectId: ProjectId,
     subscription: Subscription,
     serviceAccountPath: String,
@@ -69,7 +70,7 @@ object PubsubHttpConsumer {
   /**
     * Subscribe to the raw stream, receiving the the message as retrieved from PubSub
     */
-  final def subscribeRaw[F[_] : Concurrent : Timer](
+  final def subscribeRaw[F[_] : Concurrent : Timer : Logger](
     projectId: ProjectId,
     subscription: Subscription,
     serviceAccountPath: String,

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubHttpConsumerConfig.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubHttpConsumerConfig.scala
@@ -15,4 +15,5 @@ case class PubsubHttpConsumerConfig[F[_]](
 
   readReturnImmediately: Boolean = false,
   readMaxMessages: Int = 1000,
+  readConcurrency: Int = 1,
 )

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/PubsubSubscriber.scala
@@ -1,16 +1,19 @@
 package com.permutive.pubsub.consumer.http.internal
 
 import cats.effect._
+import cats.syntax.all._
 import com.permutive.pubsub.consumer.Model.{ProjectId, Subscription}
 import com.permutive.pubsub.consumer.http.PubsubHttpConsumerConfig
+import com.permutive.pubsub.consumer.http.internal.HttpPubsubReader.PubSubError
 import com.permutive.pubsub.consumer.http.internal.Model.AckId
 import fs2.Stream
 import fs2.concurrent.Queue
+import io.chrisdavenport.log4cats.Logger
 import org.http4s.client.Client
 
 private[http] object PubsubSubscriber {
 
-  def subscribe[F[_] : Timer](
+  def subscribe[F[_] : Timer : Logger](
     projectId: ProjectId,
     subscription: Subscription,
     serviceAccountPath: String,
@@ -19,6 +22,15 @@ private[http] object PubsubSubscriber {
   )(
     implicit F: Concurrent[F],
   ): Stream[F, Model.Record[F]] = {
+    val errorHandler: Throwable => F[Unit] = {
+      case PubSubError.NoAckIds =>
+        Logger[F].warn(s"[PubSub/Ack] a message was sent with no ids in it. This is likely a bug.")
+      case PubSubError.Unknown(e) =>
+        Logger[F].error(s"[PubSub] Unknown PubSub error occurred. Body is: ${e}")
+      case e =>
+        Logger[F].error(e)(s"[PubSub] An unknown error occurred")
+    }
+
     for {
       ackQ   <- Stream.eval(Queue.unbounded[F, AckId])
       nackQ  <- Stream.eval(Queue.unbounded[F, AckId])
@@ -31,18 +43,23 @@ private[http] object PubsubSubscriber {
           httpClient = httpClient,
         )
       )
-      rec <- Stream.repeatEval(reader.read)
+      source =
+        if (config.readConcurrency == 1) Stream.repeatEval(reader.read)
+        else Stream.emit(reader.read).repeat.covary[F].mapAsyncUnordered(config.readConcurrency)(identity)
+      rec <- source
         .concurrently(
           ackQ
             .dequeue
             .groupWithin(config.acknowledgeBatchSize, config.acknowledgeBatchLatency)
-            .evalMap(ids => reader.ack(ids.toList))
+            .evalMap(ids => reader.ack(ids.toList).handleErrorWith(errorHandler))
+            .onFinalize(Logger[F].debug("[PubSub] Ack queue has exited."))
         )
         .concurrently(
           nackQ
             .dequeue
             .groupWithin(config.acknowledgeBatchSize, config.acknowledgeBatchLatency)
-            .evalMap(ids => reader.nack(ids.toList))
+            .evalMap(ids => reader.nack(ids.toList).handleErrorWith(errorHandler))
+            .onFinalize(Logger[F].debug("[PubSub] Nack queue has exited."))
         )
       msg <- Stream.emits(
         rec.receivedMessages.map { msg =>

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/DefaultTokenProvider.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/DefaultTokenProvider.scala
@@ -6,6 +6,7 @@ import java.time.Instant
 import cats.effect.{Concurrent, Sync}
 import cats.syntax.all._
 import com.permutive.pubsub.http.crypto.GoogleAccountParser
+import io.chrisdavenport.log4cats.Logger
 import org.http4s.client.Client
 
 class DefaultTokenProvider[F[_]](
@@ -30,7 +31,7 @@ class DefaultTokenProvider[F[_]](
 }
 
 object DefaultTokenProvider {
-  def google[F[_]](
+  def google[F[_] : Logger](
     serviceAccountPath: String,
     httpClient: Client[F],
   )(

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/GoogleOAuth.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/GoogleOAuth.scala
@@ -10,7 +10,6 @@ import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.github.plokhotnyuk.jsoniter_scala.core.readFromArray
 import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.http4s.Method.POST
 import org.http4s.client.Client
 import org.http4s.client.dsl.Http4sClientDsl
@@ -19,7 +18,7 @@ import org.http4s._
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-class GoogleOAuth[F[_]](
+class GoogleOAuth[F[_] : Logger](
   key: RSAPrivateKey,
   httpClient: Client[F]
 )(
@@ -33,8 +32,6 @@ class GoogleOAuth[F[_]](
   private[this] final val algorithm = Algorithm.RSA256(null: RSAPublicKey, key)
   private[this] final val googleOAuthDomainStr = "https://www.googleapis.com/oauth2/v4/token"
   private[this] final val googleOAuthDomain = Uri.unsafeFromString(googleOAuthDomainStr)
-
-  private[this] final implicit val unsafeLogger: Logger[F] = Slf4jLogger.unsafeCreate[F]
 
   final override def authenticate(
     iss: String,

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/BatchingHttpPubsubProducer.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/BatchingHttpPubsubProducer.scala
@@ -1,16 +1,16 @@
 package com.permutive.pubsub.producer.http
 
 import cats.effect.{Concurrent, Resource, Timer}
-import cats.syntax.all._
 import com.permutive.pubsub.producer.encoder.MessageEncoder
 import com.permutive.pubsub.producer.http.internal.{BatchingHttpPublisher, DefaultHttpPublisher}
 import com.permutive.pubsub.producer.{Model, PubsubProducer}
+import io.chrisdavenport.log4cats.Logger
 import org.http4s.client.Client
 
 object BatchingHttpPubsubProducer {
   type Batch[A] = List[Model.Record[A]]
 
-  def resource[F[_] : Concurrent : Timer, A: MessageEncoder](
+  def resource[F[_] : Concurrent : Timer : Logger, A: MessageEncoder](
     projectId: Model.ProjectId,
     topic: Model.Topic,
     googleServiceAccountPath: String,

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/HttpPubsubProducer.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/HttpPubsubProducer.scala
@@ -4,10 +4,11 @@ import cats.effect.{Concurrent, Resource, Timer}
 import com.permutive.pubsub.producer.encoder.MessageEncoder
 import com.permutive.pubsub.producer.http.internal.DefaultHttpPublisher
 import com.permutive.pubsub.producer.{Model, PubsubProducer}
+import io.chrisdavenport.log4cats.Logger
 import org.http4s.client.Client
 
 object HttpPubsubProducer {
-  def resource[F[_] : Concurrent : Timer, A: MessageEncoder](
+  def resource[F[_] : Concurrent : Timer : Logger, A: MessageEncoder](
     projectId: Model.ProjectId,
     topic: Model.Topic,
     googleServiceAccountPath: String,

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/internal/DefaultHttpPublisher.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/internal/DefaultHttpPublisher.scala
@@ -13,11 +13,12 @@ import com.permutive.pubsub.producer.http.PubsubHttpProducerConfig
 import com.permutive.pubsub.http.oauth.{AccessToken, DefaultTokenProvider}
 import com.permutive.pubsub.http.util.RefreshableRef
 import com.permutive.pubsub.producer.{Model, PubsubProducer}
+import io.chrisdavenport.log4cats.Logger
 import org.http4s.Method._
 import org.http4s.Uri._
 import org.http4s._
 import org.http4s.client._
-import org.http4s.client.dsl._
+import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.headers._
 
 import scala.util.control.NoStackTrace
@@ -74,7 +75,7 @@ private[http] class DefaultHttpPublisher[F[_], A: MessageEncoder] private(
 
 private[http] object DefaultHttpPublisher {
 
-  def resource[F[_] : Concurrent : Timer, A: MessageEncoder](
+  def resource[F[_] : Concurrent : Timer : Logger, A: MessageEncoder](
     projectId: Model.ProjectId,
     topic: Model.Topic,
     serviceAccountPath: String,

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleBatching.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleBatching.scala
@@ -74,12 +74,13 @@ object ExampleBatching extends IOApp {
     client
       .flatMap(mkProducer)
       .use { producer =>
-        val value = producer.produce(
-          record = ExampleObject("1f9774be-9d7c-4dd9-8d97-855b681938a9", "example.com")
+        val value = producer.produceAsync(
+          record = ExampleObject("1f9774be-9d7c-4dd9-8d97-855b681938a9", "example.com"),
+          callback = unsafeLogger.debug("Message was sent!")
         )
 
         value >> value >> value >> IO.never
       }
-      .map(_ => ExitCode.Success)
+      .as(ExitCode.Success)
   }
 }

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleEmulator.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleEmulator.scala
@@ -1,13 +1,18 @@
 package com.permutive.pubsub.producer.http
 
-import cats.effect.{ExitCode, IO, IOApp}
+import java.util.concurrent.Executors
+
+import cats.effect._
 import cats.syntax.all._
 import com.permutive.pubsub.producer.Model
 import com.permutive.pubsub.producer.encoder.MessageEncoder
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import com.github.plokhotnyuk.jsoniter_scala.macros._
-import org.http4s.client.asynchttpclient.AsyncHttpClient
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.http4s.client.okhttp.OkHttpBuilder
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.Try
 
@@ -25,7 +30,21 @@ object ExampleEmulator extends IOApp {
     url: String,
   )
 
+  def blockingThreadPool[F[_]](implicit F: Sync[F]): Resource[F, ExecutionContext] = {
+    Resource
+      .make(F.delay(Executors.newCachedThreadPool()))(e => F.delay(e.shutdown()))
+      .map(ExecutionContext.fromExecutor)
+  }
+
   override def run(args: List[String]): IO[ExitCode] = {
+    val client = blockingThreadPool[IO].flatMap(
+      OkHttpBuilder
+        .withDefaultClient[IO](_)
+        .flatMap(_.resource)
+    )
+
+    implicit val unsafeLogger: Logger[IO] = Slf4jLogger.unsafeFromName("fs2-google-pubsub")
+
     val mkProducer = HttpPubsubProducer.resource[IO, ExampleObject](
       projectId = Model.ProjectId("test-project"),
       topic = Model.Topic("example-topic"),
@@ -39,9 +58,7 @@ object ExampleEmulator extends IOApp {
       _
     )
 
-    val http = AsyncHttpClient.resource[IO]()
-
-    http
+    client
       .flatMap(mkProducer)
       .use { producer =>
         producer.produce(

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleGoogle.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleGoogle.scala
@@ -1,13 +1,18 @@
 package com.permutive.pubsub.producer.http
 
-import cats.effect.{ExitCode, IO, IOApp}
+import java.util.concurrent.Executors
+
+import cats.effect._
 import cats.syntax.all._
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import com.github.plokhotnyuk.jsoniter_scala.macros._
 import com.permutive.pubsub.producer.Model
 import com.permutive.pubsub.producer.encoder.MessageEncoder
-import org.http4s.client.asynchttpclient.AsyncHttpClient
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.http4s.client.okhttp.OkHttpBuilder
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.Try
 
@@ -25,7 +30,21 @@ object ExampleGoogle extends IOApp {
     url: String,
   )
 
+  def blockingThreadPool[F[_]](implicit F: Sync[F]): Resource[F, ExecutionContext] = {
+    Resource
+      .make(F.delay(Executors.newCachedThreadPool()))(e => F.delay(e.shutdown()))
+      .map(ExecutionContext.fromExecutor)
+  }
+
   override def run(args: List[String]): IO[ExitCode] = {
+    val client = blockingThreadPool[IO].flatMap(
+      OkHttpBuilder
+        .withDefaultClient[IO](_)
+        .flatMap(_.resource)
+    )
+
+    implicit val unsafeLogger: Logger[IO] = Slf4jLogger.unsafeFromName("fs2-google-pubsub")
+
     val mkProducer = HttpPubsubProducer.resource[IO, ExampleObject](
       projectId = Model.ProjectId("test-project"),
       topic = Model.Topic("example-topic"),
@@ -38,11 +57,14 @@ object ExampleGoogle extends IOApp {
       _
     )
 
-    val http = AsyncHttpClient.resource[IO]()
-    http.flatMap(mkProducer).use { producer =>
-      producer.produce(
-        record = ExampleObject("70251cf8-5ffb-4c3f-8f2f-40b9bfe4147c", "example.com")
-      )
-    }.flatTap(output => IO(println(output))) >> IO.pure(ExitCode.Success)
+    client
+      .flatMap(mkProducer)
+      .use { producer =>
+        producer.produce(
+          record = ExampleObject("70251cf8-5ffb-4c3f-8f2f-40b9bfe4147c", "example.com")
+        )
+      }
+      .flatTap(output => IO(println(output)))
+      .as(ExitCode.Success)
   }
 }


### PR DESCRIPTION
The main change is that 
```scala
Stream.repeatEval(reader.read)
```
becomes
```scala
Stream
  .emit(reader.read)
  .repeat
  .covary[F]
  .mapAsyncUnordered(config.readConcurrency)(identity)
```

Other changes in this PR:
- better error handling and logging for asynchronous queues (acks and nacks)
- actually parse errors from PubSub
- do not depend on an implementation of a logger, instead make users provide it