### PR TITLE
Retry OAuth token refresh upon failure, configurable.

### DIFF
--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/PubsubHttpProducerConfig.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/PubsubHttpProducerConfig.scala
@@ -9,4 +9,8 @@ case class PubsubHttpProducerConfig[F[_]](
 
   oauthTokenRefreshInterval: FiniteDuration = 30.minutes,
   onTokenRefreshError: PartialFunction[Throwable, F[Unit]] = PartialFunction.empty,
+
+  oauthTokenFailureRetryDelay: FiniteDuration = 0.millis,
+  oauthTokenFailureRetryNextDelay: FiniteDuration => FiniteDuration = _ => 5.minutes,
+  oauthTokenFailureRetryMaxAttempts: Int = Int.MaxValue,
 )

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/PubsubHttpProducerConfig.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/PubsubHttpProducerConfig.scala
@@ -2,6 +2,18 @@ package com.permutive.pubsub.producer.http
 
 import scala.concurrent.duration._
 
+/**
+  * Configuration for the PubSub HTTP producer.
+  *
+  * @param host                              host of PubSub
+  * @param port                              port of PubSub
+  * @param isEmulator                        whether the target PubSub is an emulator or not
+  * @param oauthTokenRefreshInterval         how often to refresh the Google OAuth token
+  * @param onTokenRefreshError               what to do if the token refresh fails
+  * @param oauthTokenFailureRetryDelay       initial delay for retrying OAuth token retrieval
+  * @param oauthTokenFailureRetryNextDelay   next delay for retrying OAuth token retrieval
+  * @param oauthTokenFailureRetryMaxAttempts how many times to attempt
+  */
 case class PubsubHttpProducerConfig[F[_]](
   host: String = "pubsub.googleapis.com",
   port: Int = 443,


### PR DESCRIPTION
Currently, if the OAuth token retrieval fails, the next time it will be retry is only in half an hour.

This PR makes it possible to configure retry logic for token retrieval.

New params are available:
```
  oauthTokenFailureRetryDelay: FiniteDuration = 0.millis,
  oauthTokenFailureRetryNextDelay: FiniteDuration => FiniteDuration = _ => 5.minutes,
  oauthTokenFailureRetryMaxAttempts: Int = Int.MaxValue,
```