### PR TITLE
Change AsyncPubsubProducer to return nested effects

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -5,7 +5,7 @@ import mill.scalalib.publish._
 object Dependencies {
   object version {
     val catsCore = "1.6.0"
-    val effect   = "1.2.0"
+    val effect   = "1.3.0"
     val fs2      = "1.0.4"
     val http4s   = "0.20.0"
     val log4cats = "0.3.0"
@@ -51,7 +51,8 @@ trait CommonModule extends SbtModule with PublishModule {
     versionControl = VersionControl.github("permutive", "fs2-google-pubsub"),
     developers = Seq(
       Developer("cremboc", "Paulius Imbrasas", "https://github.com/cremboc"),
-      Developer("TimWSpence", "Tim Spence", "https://github.com/TimWSpence")
+      Developer("TimWSpence", "Tim Spence", "https://github.com/TimWSpence"),
+      Developer("bastewart", "Ben Stewart", "https://github.com/bastewart"),
     )
   )
 

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/BatchingHttpPubsubProducer.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/BatchingHttpPubsubProducer.scala
@@ -4,20 +4,16 @@ import cats.effect.{Concurrent, Resource, Timer}
 import com.permutive.pubsub.producer.encoder.MessageEncoder
 import com.permutive.pubsub.producer.http.internal.{BatchingHttpPublisher, DefaultHttpPublisher}
 import com.permutive.pubsub.producer.{AsyncPubsubProducer, Model}
-import fs2.Chunk
 import io.chrisdavenport.log4cats.Logger
 import org.http4s.client.Client
 
 object BatchingHttpPubsubProducer {
-  type Batch[F[_], A] = Chunk[Model.AsyncRecord[F, A]]
-
   def resource[F[_] : Concurrent : Timer : Logger, A: MessageEncoder](
     projectId: Model.ProjectId,
     topic: Model.Topic,
     googleServiceAccountPath: String,
     config: PubsubHttpProducerConfig[F],
     batchingConfig: BatchingHttpProducerConfig,
-    onPublishFailure: (Batch[F, A], Throwable) => F[Unit],
     httpClient: Client[F],
   ): Resource[F, AsyncPubsubProducer[F, A]] = {
     for {
@@ -31,7 +27,6 @@ object BatchingHttpPubsubProducer {
       batching <- BatchingHttpPublisher.resource(
         publisher = publisher,
         config = batchingConfig,
-        onPublishFailure = onPublishFailure,
       )
     } yield batching
   }

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/internal/BatchingHttpPublisher.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/internal/BatchingHttpPublisher.scala
@@ -1,55 +1,60 @@
 package com.permutive.pubsub.producer.http.internal
 
 import cats.Traverse
+import cats.effect.concurrent.Deferred
 import cats.effect.syntax.all._
 import cats.effect.{Concurrent, Resource, Timer}
 import cats.syntax.all._
+import com.permutive.pubsub.producer.Model.MessageId
 import com.permutive.pubsub.producer.encoder.MessageEncoder
 import com.permutive.pubsub.producer.http.BatchingHttpProducerConfig
-import com.permutive.pubsub.producer.http.BatchingHttpPubsubProducer.Batch
+import com.permutive.pubsub.producer.http.internal.BatchingHttpPublisher.EnqueuedRecord
 import com.permutive.pubsub.producer.{AsyncPubsubProducer, Model, PubsubProducer}
 import fs2.Chunk._
 import fs2.concurrent.{Enqueue, Queue}
 import fs2.{Chunk, Stream}
 
 private[http] class BatchingHttpPublisher[F[_] : Concurrent : Timer, A: MessageEncoder] private(
-  queue: Enqueue[F, Model.AsyncRecord[F, A]],
+  queue: Enqueue[F, EnqueuedRecord[F, A]],
 ) extends AsyncPubsubProducer[F, A] {
 
   override def produceAsync(
     record: A,
-    callback: F[Unit],
     metadata: Map[String, String],
-    uniqueId: String
-  ): F[Unit] = {
-    queue.enqueue1(Model.AsyncRecord(record, callback, metadata, uniqueId))
-  }
+    uniqueId: String,
+  ): F[F[Unit]] =
+    produceAsync(Model.Record(record, metadata, uniqueId))
 
-  override def produceManyAsync[G[_] : Traverse](records: G[Model.AsyncRecord[F, A]]): F[Unit] =
-    records.traverse(queue.enqueue1).void
+  override def produceManyAsync[G[_] : Traverse](records: G[Model.Record[A]]): F[G[F[Unit]]] =
+    records.traverse(produceAsync)
+
+  private def produceAsync(record: Model.Record[A]): F[F[Unit]] =
+    for {
+      d <- Deferred[F, Either[Throwable, Unit]]
+      _ <- queue.enqueue1(EnqueuedRecord(d, record))
+    } yield d.get.rethrow
+
 }
 
 private[http] object BatchingHttpPublisher {
   def resource[F[_] : Concurrent : Timer, A: MessageEncoder](
     publisher: PubsubProducer[F, A],
     config: BatchingHttpProducerConfig,
-    onPublishFailure: (Batch[F, A], Throwable) => F[Unit],
   ): Resource[F, AsyncPubsubProducer[F, A]] = {
     for {
-      queue <- Resource.liftF(Queue.unbounded[F, Model.AsyncRecord[F, A]])
-      _ <- Resource.make(consume(publisher, config, queue, onPublishFailure).start)(_.cancel)
+      queue <- Resource.liftF(Queue.unbounded[F, EnqueuedRecord[F, A]])
+      _ <- Resource.make(consume(publisher, config, queue).start)(_.cancel)
     } yield new BatchingHttpPublisher(queue)
   }
 
   private def consume[F[_] : Concurrent : Timer, A: MessageEncoder](
     underlying: PubsubProducer[F, A],
     config: BatchingHttpProducerConfig,
-    queue: Queue[F, Model.AsyncRecord[F, A]],
-    onPublishFailure: (Batch[F, A], Throwable) => F[Unit],
+    queue: Queue[F, EnqueuedRecord[F, A]],
   ): F[Unit] = {
-    val handler: Chunk[Model.AsyncRecord[F, A]] => F[Unit] =
+    val handler: Chunk[Model.Record[A]] => F[List[MessageId]] =
       if (config.retryTimes == 0) {
-        records => underlying.produceMany[Chunk](records) >> records.traverse_(_.callback)
+        records => underlying.produceMany[Chunk](records)
       } else {
         records =>
           Stream.retry(
@@ -57,16 +62,21 @@ private[http] object BatchingHttpPublisher {
             delay = config.retryInitialDelay,
             nextDelay = config.retryNextDelay,
             maxAttempts = config.retryTimes,
-          ).compile.lastOrError >> records.traverse_(_.callback)
+          ).compile.lastOrError
       }
 
     queue
       .dequeue
       .groupWithin(config.batchSize, config.maxLatency)
-      .evalMap { records =>
-        handler(records).handleErrorWith(onPublishFailure(records, _))
+      .evalMap { enqueuedRecords =>
+        handler(enqueuedRecords.map(_.record))
+          .void
+          .attempt
+          .flatMap(etu => enqueuedRecords.traverse(_.deferred.complete(etu)))
       }
       .compile
       .drain
   }
+
+  case class EnqueuedRecord[F[_], A](deferred: Deferred[F, Either[Throwable, Unit]], record: Model.Record[A])
 }

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/AsyncPubsubProducer.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/AsyncPubsubProducer.scala
@@ -7,12 +7,11 @@ import cats.Traverse
 trait AsyncPubsubProducer[F[_], A] {
   def produceAsync(
     record: A,
-    callback: F[Unit],
     metadata: Map[String, String] = Map.empty,
     uniqueId: String = UUID.randomUUID().toString,
-  ): F[Unit]
+  ): F[F[Unit]]
 
   def produceManyAsync[G[_] : Traverse](
-    records: G[Model.AsyncRecord[F, A]],
-  ): F[Unit]
+    records: G[Model.Record[A]],
+  ): F[G[F[Unit]]]
 }

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/Model.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/Model.scala
@@ -3,25 +3,13 @@ package com.permutive.pubsub.producer
 import java.util.UUID
 
 object Model {
+  case class MessageId(value: String) extends AnyVal
   case class ProjectId(value: String) extends AnyVal
   case class Topic(value: String) extends AnyVal
 
-  trait Record[A] {
-    def value: A
-    def metadata: Map[String, String]
-    def uniqueId: String
-  }
-
-  case class SimpleRecord[A](
+  case class Record[A](
     value: A,
     metadata: Map[String, String] = Map.empty,
     uniqueId: String = UUID.randomUUID().toString
-  ) extends Record[A]
-
-  case class AsyncRecord[F[_], A](
-    value: A,
-    callback: F[Unit],
-    metadata: Map[String, String] = Map.empty,
-    uniqueId: String = UUID.randomUUID().toString,
-  ) extends Record[A]
+  )
 }

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/PubsubProducer.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/PubsubProducer.scala
@@ -3,13 +3,14 @@ package com.permutive.pubsub.producer
 import java.util.UUID
 
 import cats.Traverse
+import com.permutive.pubsub.producer.Model.MessageId
 
 trait PubsubProducer[F[_], A] {
   def produce(
     record: A,
     metadata: Map[String, String] = Map.empty,
     uniqueId: String = UUID.randomUUID().toString,
-  ): F[String]
+  ): F[MessageId]
 
-  def produceMany[G[_] : Traverse](records: G[Model.Record[A]]): F[List[String]]
+  def produceMany[G[_] : Traverse](records: G[Model.Record[A]]): F[List[MessageId]]
 }


### PR DESCRIPTION
Outer effect represents publishing, inner awaiting result of publish.

Also:
* Add new `MessageId` class and make publishers return this, not `String`
* Remove `AsyncRecord` and `SimpleRecord` as both can be a `Record` now
* Update `cats-effect` to `1.3.0`