### PR TITLE
Add callback async publishing back to AsyncPubsubProducer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/internal/BatchingHttpPublisher.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/internal/BatchingHttpPublisher.scala
@@ -1,6 +1,6 @@
 package com.permutive.pubsub.producer.http.internal
 
-import cats.Traverse
+import cats.{Foldable, Traverse}
 import cats.effect.concurrent.Deferred
 import cats.effect.syntax.all._
 import cats.effect.{Concurrent, Resource, Timer}
@@ -8,30 +8,40 @@ import cats.syntax.all._
 import com.permutive.pubsub.producer.Model.MessageId
 import com.permutive.pubsub.producer.encoder.MessageEncoder
 import com.permutive.pubsub.producer.http.BatchingHttpProducerConfig
-import com.permutive.pubsub.producer.http.internal.BatchingHttpPublisher.EnqueuedRecord
 import com.permutive.pubsub.producer.{AsyncPubsubProducer, Model, PubsubProducer}
 import fs2.Chunk._
-import fs2.concurrent.{Enqueue, Queue}
+import fs2.concurrent.{Dequeue, Enqueue, Queue}
 import fs2.{Chunk, Stream}
 
-private[http] class BatchingHttpPublisher[F[_] : Concurrent : Timer, A: MessageEncoder] private(
-  queue: Enqueue[F, EnqueuedRecord[F, A]],
-) extends AsyncPubsubProducer[F, A] {
+private[http] class BatchingHttpPublisher[F[_] : Timer, A: MessageEncoder] private(
+  queue: Enqueue[F, Model.AsyncRecord[F, A]],
+)(implicit F: Concurrent[F]) extends AsyncPubsubProducer[F, A] {
 
   override def produceAsync(
+    record: A,
+    callback: Either[Throwable, Unit] => F[Unit],
+    metadata: Map[String, String],
+    uniqueId: String
+  ): F[Unit] =
+    queue.enqueue1(Model.AsyncRecord(record, callback, metadata, uniqueId))
+
+  override def produceManyAsync[G[_] : Foldable](records: G[Model.AsyncRecord[F, A]]): F[Unit] =
+    records.traverse_(queue.enqueue1)
+
+  override def produce(
     record: A,
     metadata: Map[String, String],
     uniqueId: String,
   ): F[F[Unit]] =
-    produceAsync(Model.Record(record, metadata, uniqueId))
+    produceAsync(Model.SimpleRecord(record, metadata, uniqueId))
 
-  override def produceManyAsync[G[_] : Traverse](records: G[Model.Record[A]]): F[G[F[Unit]]] =
+  override def produceMany[G[_] : Traverse](records: G[Model.SimpleRecord[A]]): F[G[F[Unit]]] =
     records.traverse(produceAsync)
 
-  private def produceAsync(record: Model.Record[A]): F[F[Unit]] =
+  private def produceAsync(record: Model.SimpleRecord[A]): F[F[Unit]] =
     for {
       d <- Deferred[F, Either[Throwable, Unit]]
-      _ <- queue.enqueue1(EnqueuedRecord(d, record))
+      _ <- queue.enqueue1(Model.AsyncRecord(record.value, d.complete, record.metadata, record.uniqueId))
     } yield d.get.rethrow
 
 }
@@ -42,7 +52,7 @@ private[http] object BatchingHttpPublisher {
     config: BatchingHttpProducerConfig,
   ): Resource[F, AsyncPubsubProducer[F, A]] = {
     for {
-      queue <- Resource.liftF(Queue.unbounded[F, EnqueuedRecord[F, A]])
+      queue <- Resource.liftF(Queue.unbounded[F, Model.AsyncRecord[F, A]])
       _ <- Resource.make(consume(publisher, config, queue).start)(_.cancel)
     } yield new BatchingHttpPublisher(queue)
   }
@@ -50,9 +60,9 @@ private[http] object BatchingHttpPublisher {
   private def consume[F[_] : Concurrent : Timer, A: MessageEncoder](
     underlying: PubsubProducer[F, A],
     config: BatchingHttpProducerConfig,
-    queue: Queue[F, EnqueuedRecord[F, A]],
+    queue: Dequeue[F, Model.AsyncRecord[F, A]],
   ): F[Unit] = {
-    val handler: Chunk[Model.Record[A]] => F[List[MessageId]] =
+    val handler: Chunk[Model.AsyncRecord[F, A]] => F[List[MessageId]] =
       if (config.retryTimes == 0) {
         records => underlying.produceMany[Chunk](records)
       } else {
@@ -68,15 +78,13 @@ private[http] object BatchingHttpPublisher {
     queue
       .dequeue
       .groupWithin(config.batchSize, config.maxLatency)
-      .evalMap { enqueuedRecords =>
-        handler(enqueuedRecords.map(_.record))
+      .evalMap { asyncRecords =>
+        handler(asyncRecords)
           .void
           .attempt
-          .flatMap(etu => enqueuedRecords.traverse(_.deferred.complete(etu)))
+          .flatMap(etu => asyncRecords.traverse_(_.callback(etu)))
       }
       .compile
       .drain
   }
-
-  case class EnqueuedRecord[F[_], A](deferred: Deferred[F, Either[Throwable, Unit]], record: Model.Record[A])
 }

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/internal/DefaultHttpPublisher.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/internal/DefaultHttpPublisher.scala
@@ -40,7 +40,7 @@ private[http] class DefaultHttpPublisher[F[_], A: MessageEncoder] private(
   private[this] final val publishRoute = baseApiUrl.copy(path = baseApiUrl.path.concat(":publish"))
 
   override final def produce(record: A, metadata: Map[String, String], uniqueId: String): F[MessageId] = {
-    produceMany[List](List(Model.Record(record, metadata, uniqueId))).map(_.head)
+    produceMany[List](List(Model.SimpleRecord(record, metadata, uniqueId))).map(_.head)
   }
 
   override final def produceMany[G[_]: Traverse](records: G[Model.Record[A]]): F[List[MessageId]] = {

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleBatching.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleBatching.scala
@@ -66,23 +66,35 @@ object ExampleBatching extends IOApp {
       _
     )
 
+    val messageCallback: Either[Throwable, Unit] => IO[Unit] = {
+      case Right(_) => Logger[IO].info("Async message was sent successfully!")
+      case Left(e) => Logger[IO].warn(e)("Async message was sent unsuccessfully!")
+    }
+
     client
       .flatMap(mkProducer)
       .use { producer =>
-        val value = producer.produceAsync(
+        val produceOne = producer.produce(
           record = ExampleObject("1f9774be-9d7c-4dd9-8d97-855b681938a9", "example.com"),
         )
 
+        val produceOneAsync = producer.produceAsync(
+          record = ExampleObject("a84a3318-adbd-4eac-af78-eacf33be91ef", "example.com"),
+          callback = messageCallback
+        )
+
         for {
-          result1 <- value
-          result2 <- value
-          result3 <- value
+          result1 <- produceOne
+          result2 <- produceOne
+          result3 <- produceOne
           _       <- result1
           _       <- Logger[IO].info("First message was sent!")
           _       <- result2
           _       <- Logger[IO].info("Second message was sent!")
           _       <- result3
           _       <- Logger[IO].info("Third message was sent!")
+          _       <- produceOneAsync
+          _       <- IO.never
         } yield ()
       }
       .as(ExitCode.Success)

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/AsyncPubsubProducer.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/AsyncPubsubProducer.scala
@@ -2,16 +2,27 @@ package com.permutive.pubsub.producer
 
 import java.util.UUID
 
-import cats.Traverse
+import cats.{Foldable, Traverse}
 
 trait AsyncPubsubProducer[F[_], A] {
   def produceAsync(
+    record: A,
+    callback: Either[Throwable, Unit] => F[Unit],
+    metadata: Map[String, String] = Map.empty,
+    uniqueId: String = UUID.randomUUID().toString,
+  ): F[Unit]
+
+  def produceManyAsync[G[_] : Foldable](
+    records: G[Model.AsyncRecord[F, A]],
+  ): F[Unit]
+
+  def produce(
     record: A,
     metadata: Map[String, String] = Map.empty,
     uniqueId: String = UUID.randomUUID().toString,
   ): F[F[Unit]]
 
-  def produceManyAsync[G[_] : Traverse](
-    records: G[Model.Record[A]],
+  def produceMany[G[_] : Traverse](
+    records: G[Model.SimpleRecord[A]],
   ): F[G[F[Unit]]]
 }

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/Model.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/Model.scala
@@ -7,9 +7,22 @@ object Model {
   case class ProjectId(value: String) extends AnyVal
   case class Topic(value: String) extends AnyVal
 
-  case class Record[A](
+  trait Record[A] {
+    def value: A
+    def metadata: Map[String, String]
+    def uniqueId: String
+  }
+
+  final case class SimpleRecord[A](
     value: A,
     metadata: Map[String, String] = Map.empty,
     uniqueId: String = UUID.randomUUID().toString
-  )
+  ) extends Record[A]
+
+  final case class AsyncRecord[F[_], A](
+    value: A,
+    callback: Either[Throwable, Unit] => F[Unit],
+    metadata: Map[String, String] = Map.empty,
+    uniqueId: String = UUID.randomUUID().toString,
+  ) extends Record[A]
 }


### PR DESCRIPTION
Now the callback includes information about if the publish succeeded or
failed.

Also rename nested effect async producing to produce and produceMany.
Makes naming more consistent with previous release version.