### PR TITLE
Updates for 2.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,5 @@ install:
   - sudo sh -c '(echo "#!/usr/bin/env sh" && curl -L https://github.com/lihaoyi/mill/releases/download/0.3.6/0.3.6) > /usr/local/bin/mill && chmod +x /usr/local/bin/mill'
 
 script:
+  - mill __.test
   - mill __.publishLocal

--- a/build.sc
+++ b/build.sc
@@ -130,6 +130,7 @@ trait CommonModule extends CrossSbtModule with PublishModule {
 object `fs2-google-pubsub` extends Cross[`fs2-google-pubsub`](Dependencies.version.cross:_*)
 class `fs2-google-pubsub`(val crossScalaVersion: String) extends CommonModule {
   override def ivyDeps = commonDependencies
+  override def artifactName = "fs2-google-pubsub"
 }
 
 object `fs2-google-pubsub-http` extends Cross[`fs2-google-pubsub-http`](Dependencies.version.cross:_*)
@@ -137,6 +138,7 @@ class `fs2-google-pubsub-http`(val crossScalaVersion: String) extends CommonModu
   override def moduleDeps = List(`fs2-google-pubsub`(crossScalaVersion))
   override def ivyDeps = commonDependencies ++ httpDependencies
   override def compileIvyDeps = httpCompileDependencies
+  override def artifactName = "fs2-google-pubsub-http"
 
   object test extends Tests {
     override def ivyDeps = Agg(
@@ -158,6 +160,7 @@ object `fs2-google-pubsub-grpc` extends Cross[`fs2-google-pubsub-grpc`](Dependen
 class `fs2-google-pubsub-grpc`(val crossScalaVersion: String) extends CommonModule {
   override def moduleDeps = List(`fs2-google-pubsub`(crossScalaVersion))
   override def ivyDeps = commonDependencies ++ grpcDependencies
+  override def artifactName = "fs2-google-pubsub-grpc"
 
   object test extends Tests {
     override def ivyDeps = Agg(

--- a/build.sc
+++ b/build.sc
@@ -3,7 +3,13 @@ import mill.scalalib._
 import mill.scalalib.publish._
 
 object Dependencies {
+
   object version {
+    val scala212 = "2.12.8"
+    val scala213 = "2.13.0-RC3"
+
+    val cross    = List(scala212, scala213)
+
     val catsCore = "1.6.1"
     val effect   = "1.3.1"
     val fs2      = "1.0.5"
@@ -39,8 +45,7 @@ object Dependencies {
   }
 }
 
-trait CommonModule extends SbtModule with PublishModule {
-  def scalaVersion = "2.12.8"
+trait CommonModule extends SbtModule with PublishModule with CrossScalaModule {
   def publishVersion = "0.13.3-SNAPSHOT"
 
   def pomSettings = PomSettings(
@@ -117,12 +122,14 @@ trait CommonModule extends SbtModule with PublishModule {
   )
 }
 
-object `fs2-google-pubsub` extends CommonModule {
+object `fs2-google-pubsub` extends Cross[`fs2-google-pubsub`](Dependencies.version.cross:_*)
+class `fs2-google-pubsub`(val crossScalaVersion: String) extends CommonModule {
   override def ivyDeps = commonDependencies
 }
 
-object `fs2-google-pubsub-http` extends CommonModule {
-  override def moduleDeps = List(`fs2-google-pubsub`)
+object `fs2-google-pubsub-http` extends Cross[`fs2-google-pubsub-http`](Dependencies.version.cross:_*)
+class `fs2-google-pubsub-http`(val crossScalaVersion: String) extends CommonModule {
+  override def moduleDeps = List(`fs2-google-pubsub`(crossScalaVersion))
   override def ivyDeps = commonDependencies ++ httpDependencies
   override def compileIvyDeps = httpCompileDependencies
 
@@ -141,7 +148,8 @@ object `fs2-google-pubsub-http` extends CommonModule {
   }
 }
 
-object `fs2-google-pubsub-grpc` extends CommonModule {
-  override def moduleDeps = List(`fs2-google-pubsub`)
+object `fs2-google-pubsub-grpc` extends Cross[`fs2-google-pubsub-grpc`](Dependencies.version.cross:_*)
+class `fs2-google-pubsub-grpc`(val crossScalaVersion: String) extends CommonModule {
+  override def moduleDeps = List(`fs2-google-pubsub`(crossScalaVersion))
   override def ivyDeps = commonDependencies ++ grpcDependencies
 }

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/consumer/http/Example.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/consumer/http/Example.scala
@@ -1,7 +1,5 @@
 package com.permutive.pubsub.consumer.http
 
-import java.util.concurrent.Executors
-
 import cats.effect._
 import cats.syntax.all._
 import com.permutive.pubsub.consumer.Model
@@ -11,7 +9,6 @@ import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.http4s.client.okhttp.OkHttpBuilder
 
-import scala.concurrent.ExecutionContext
 import scala.util.Try
 
 object Example extends IOApp {
@@ -21,14 +18,8 @@ object Example extends IOApp {
     Try(ValueHolder(new String(bytes))).toEither
   }
 
-  def blockingThreadPool[F[_]](implicit F: Sync[F]): Resource[F, ExecutionContext] = {
-    Resource
-      .make(F.delay(Executors.newCachedThreadPool()))(e => F.delay(e.shutdown()))
-      .map(ExecutionContext.fromExecutor)
-  }
-
   override def run(args: List[String]): IO[ExitCode] = {
-    val client = blockingThreadPool[IO].flatMap(
+    val client = Blocker[IO].flatMap(
       OkHttpBuilder
         .withDefaultClient[IO](_)
         .flatMap(_.resource)

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleBatching.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleBatching.scala
@@ -1,7 +1,5 @@
 package com.permutive.pubsub.producer.http
 
-import java.util.concurrent.Executors
-
 import cats.effect._
 import cats.syntax.all._
 import com.github.plokhotnyuk.jsoniter_scala.core._
@@ -12,7 +10,6 @@ import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.http4s.client.okhttp.OkHttpBuilder
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.Try
 
@@ -30,14 +27,8 @@ object ExampleBatching extends IOApp {
     url: String,
   )
 
-  def blockingThreadPool[F[_]](implicit F: Sync[F]): Resource[F, ExecutionContext] = {
-    Resource
-      .make(F.delay(Executors.newCachedThreadPool()))(e => F.delay(e.shutdown()))
-      .map(ExecutionContext.fromExecutor)
-  }
-
   override def run(args: List[String]): IO[ExitCode] = {
-    val client = blockingThreadPool[IO].flatMap(
+    val client = Blocker[IO].flatMap(
       OkHttpBuilder
         .withDefaultClient[IO](_)
         .flatMap(_.resource)

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleEmulator.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleEmulator.scala
@@ -1,7 +1,5 @@
 package com.permutive.pubsub.producer.http
 
-import java.util.concurrent.Executors
-
 import cats.effect._
 import cats.syntax.all._
 import com.permutive.pubsub.producer.Model
@@ -12,7 +10,6 @@ import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.http4s.client.okhttp.OkHttpBuilder
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.Try
 
@@ -30,14 +27,8 @@ object ExampleEmulator extends IOApp {
     url: String,
   )
 
-  def blockingThreadPool[F[_]](implicit F: Sync[F]): Resource[F, ExecutionContext] = {
-    Resource
-      .make(F.delay(Executors.newCachedThreadPool()))(e => F.delay(e.shutdown()))
-      .map(ExecutionContext.fromExecutor)
-  }
-
   override def run(args: List[String]): IO[ExitCode] = {
-    val client = blockingThreadPool[IO].flatMap(
+    val client = Blocker[IO].flatMap(
       OkHttpBuilder
         .withDefaultClient[IO](_)
         .flatMap(_.resource)

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleGoogle.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleGoogle.scala
@@ -1,7 +1,5 @@
 package com.permutive.pubsub.producer.http
 
-import java.util.concurrent.Executors
-
 import cats.effect._
 import cats.syntax.all._
 import com.github.plokhotnyuk.jsoniter_scala.core._
@@ -12,7 +10,6 @@ import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.http4s.client.okhttp.OkHttpBuilder
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.Try
 
@@ -30,14 +27,8 @@ object ExampleGoogle extends IOApp {
     url: String,
   )
 
-  def blockingThreadPool[F[_]](implicit F: Sync[F]): Resource[F, ExecutionContext] = {
-    Resource
-      .make(F.delay(Executors.newCachedThreadPool()))(e => F.delay(e.shutdown()))
-      .map(ExecutionContext.fromExecutor)
-  }
-
   override def run(args: List[String]): IO[ExitCode] = {
-    val client = blockingThreadPool[IO].flatMap(
+    val client = Blocker[IO].flatMap(
       OkHttpBuilder
         .withDefaultClient[IO](_)
         .flatMap(_.resource)


### PR DESCRIPTION
This includes the commit from #16 and updates dependencies for 2.13.0.

A couple of notes:
* cats-effect now includes a nice `Blocker` API that manages its own cached thread pool, so I've switched to using that.
* I'm using `CrossSbtModule` instead of `CrossScalaModule` + `SbtModule`, since that combo was breaking the test module paths.
* I've added a test module for `fs2-google-pubsub-grpc` so that example code gets included in the build.
* I've added `mill __.test` to Travis so the example projects get compiled.

r? @CremboC 