### PR TITLE
Temporarily drop 2.13; update dependencies to latest final releases

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -5,19 +5,19 @@ import mill.scalalib.publish._
 object Dependencies {
 
   object version {
-    val scala212 = "2.12.8"
+    val scala212 = "2.12.9"
     val scala213 = "2.13.0"
 
-    val cross    = List(scala212, scala213)
+    val cross    = List(scala212)
 
-    val catsCore = "2.0.0-M4"
-    val effect   = "2.0.0-M4"
-    val fs2      = "1.1.0-M1"
-    val http4s   = "0.21.0-M2"
-    val log4cats = "0.4.0-M2"
-    val jwt      = "3.8.1"
-    val jsoniter = "0.52.2"
-    val gcp      = "1.77.0"
+    val catsCore = "1.6.1"
+    val effect   = "1.4.0"
+    val fs2      = "1.0.5"
+    val http4s   = "0.20.10"
+    val log4cats = "0.3.0"
+    val jwt      = "3.8.2"
+    val jsoniter = "0.55.0"
+    val gcp      = "1.87.0"
 
     val scalatest = "3.1.0-SNAP13"
     val scalatestPlus = "1.0.0-SNAP8"

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/consumer/http/Example.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/consumer/http/Example.scala
@@ -19,9 +19,9 @@ object Example extends IOApp {
   }
 
   override def run(args: List[String]): IO[ExitCode] = {
-    val client = Blocker[IO].flatMap(
+    val client = Blocker[IO].flatMap(blocker =>
       OkHttpBuilder
-        .withDefaultClient[IO](_)
+        .withDefaultClient[IO](blocker.blockingContext)
         .flatMap(_.resource)
     )
 

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleBatching.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleBatching.scala
@@ -28,9 +28,9 @@ object ExampleBatching extends IOApp {
   )
 
   override def run(args: List[String]): IO[ExitCode] = {
-    val client = Blocker[IO].flatMap(
+    val client = Blocker[IO].flatMap(blocker =>
       OkHttpBuilder
-        .withDefaultClient[IO](_)
+        .withDefaultClient[IO](blocker.blockingContext)
         .flatMap(_.resource)
     )
 

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleEmulator.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleEmulator.scala
@@ -28,9 +28,9 @@ object ExampleEmulator extends IOApp {
   )
 
   override def run(args: List[String]): IO[ExitCode] = {
-    val client = Blocker[IO].flatMap(
+    val client = Blocker[IO].flatMap(blocker =>
       OkHttpBuilder
-        .withDefaultClient[IO](_)
+        .withDefaultClient[IO](blocker.blockingContext)
         .flatMap(_.resource)
     )
 

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleGoogle.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleGoogle.scala
@@ -28,9 +28,9 @@ object ExampleGoogle extends IOApp {
   )
 
   override def run(args: List[String]): IO[ExitCode] = {
-    val client = Blocker[IO].flatMap(
+    val client = Blocker[IO].flatMap(blocker =>
       OkHttpBuilder
-        .withDefaultClient[IO](_)
+        .withDefaultClient[IO](blocker.blockingContext)
         .flatMap(_.resource)
     )
 


### PR DESCRIPTION
I jumped the gun on 0.14.0-M1—it turns out we need another set of dependency updates before Cats 2.0.0. This PR temporarily drops the Scala 2.13 build and updates all other dependencies to the latest non-milestone or RC versions.