### PR TITLE
Scalafmt again

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -3,6 +3,6 @@ version = 2.0.1
 align = more
 continuationIndent.defnSite = 2
 maxColumn = 120
-trailingCommas = never
+trailingCommas = preserve
 
 rewrite.rules = [RedundantBraces, RedundantParens, SortImports, SortModifiers]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,8 @@
+version = 2.0.0-RC7
+
+align = more
+continuationIndent.defnSite = 2
+maxColumn = 120
+trailingCommas = always
+
+rewrite.rules = [RedundantBraces, RedundantParens, SortImports, SortModifiers]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -3,6 +3,6 @@ version = 2.0.1
 align = more
 continuationIndent.defnSite = 2
 maxColumn = 120
-trailingCommas = always
+trailingCommas = never
 
 rewrite.rules = [RedundantBraces, RedundantParens, SortImports, SortModifiers]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,5 +4,7 @@ align = more
 continuationIndent.defnSite = 2
 maxColumn = 120
 trailingCommas = preserve
+danglingParentheses = true
+assumeStandardLibraryStripMargin = true
 
 rewrite.rules = [RedundantBraces, RedundantParens, SortImports, SortModifiers]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 2.0.0-RC7
+version = 2.0.1
 
 align = more
 continuationIndent.defnSite = 2

--- a/build.sc
+++ b/build.sc
@@ -1,6 +1,7 @@
 import mill._
 import mill.scalalib._
 import mill.scalalib.publish._
+import mill.scalalib.scalafmt._
 
 object Dependencies {
 
@@ -47,7 +48,7 @@ object Dependencies {
   }
 }
 
-trait CommonModule extends CrossSbtModule with PublishModule {
+trait CommonModule extends CrossSbtModule with PublishModule with ScalafmtModule {
   def publishVersion = "0.15.0-SNAPSHOT"
 
   def pomSettings = PomSettings(

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumer.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumer.scala
@@ -21,7 +21,7 @@ object PubsubGoogleConsumer {
     projectId: Model.ProjectId,
     subscription: Model.Subscription,
     errorHandler: (PubsubMessage, Throwable, F[Unit], F[Unit]) => F[Unit],
-    config: PubsubGoogleConsumerConfig[F],
+    config: PubsubGoogleConsumerConfig[F]
   ): Stream[F, Model.Record[F, A]] =
     PubsubSubscriber
       .subscribe(projectId, subscription, config)
@@ -44,7 +44,7 @@ object PubsubGoogleConsumer {
     projectId: Model.ProjectId,
     subscription: Model.Subscription,
     errorHandler: (PubsubMessage, Throwable, F[Unit], F[Unit]) => F[Unit],
-    config: PubsubGoogleConsumerConfig[F],
+    config: PubsubGoogleConsumerConfig[F]
   ): Stream[F, A] =
     PubsubSubscriber
       .subscribe(projectId, subscription, config)
@@ -62,7 +62,7 @@ object PubsubGoogleConsumer {
   final def subscribeRaw[F[_]: Concurrent: ContextShift](
     projectId: Model.ProjectId,
     subscription: Model.Subscription,
-    config: PubsubGoogleConsumerConfig[F],
+    config: PubsubGoogleConsumerConfig[F]
   ): Stream[F, Model.Record[F, PubsubMessage]] =
     PubsubSubscriber
       .subscribe(projectId, subscription, config)

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumerConfig.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumerConfig.scala
@@ -16,13 +16,9 @@ import scala.concurrent.duration._
   */
 case class PubsubGoogleConsumerConfig[F[_]](
   maxQueueSize: Int = 1000,
-
   parallelPullCount: Int = 3,
   maxAckExtensionPeriod: FiniteDuration = 10.seconds,
-
   awaitTerminatePeriod: FiniteDuration = 30.seconds,
-
   onFailedTerminate: Throwable => F[Unit],
-
   customizeSubscriber: Option[Subscriber.Builder => Subscriber.Builder] = None,
 )

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumerConfig.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumerConfig.scala
@@ -20,5 +20,5 @@ case class PubsubGoogleConsumerConfig[F[_]](
   maxAckExtensionPeriod: FiniteDuration = 10.seconds,
   awaitTerminatePeriod: FiniteDuration = 30.seconds,
   onFailedTerminate: Throwable => F[Unit],
-  customizeSubscriber: Option[Subscriber.Builder => Subscriber.Builder] = None,
+  customizeSubscriber: Option[Subscriber.Builder => Subscriber.Builder] = None
 )

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
@@ -18,9 +18,9 @@ private[consumer] object PubsubSubscriber {
   def createSubscriber[F[_]](
     projectId: PublicModel.ProjectId,
     subscription: PublicModel.Subscription,
-    config: PubsubGoogleConsumerConfig[F],
+    config: PubsubGoogleConsumerConfig[F]
   )(
-    implicit F: Concurrent[F],
+    implicit F: Concurrent[F]
   ): Resource[F, BlockingQueue[Model.Record[F]]] =
     Resource[F, BlockingQueue[Model.Record[F]]] {
       Sync[F].delay {
@@ -39,7 +39,7 @@ private[consumer] object PubsubSubscriber {
               FlowControlSettings
                 .newBuilder()
                 .setMaxOutstandingElementCount(config.maxQueueSize.toLong)
-                .build(),
+                .build()
             )
             .setParallelPullCount(config.parallelPullCount)
             .setMaxAckExtensionPeriod(Duration.ofMillis(config.maxAckExtensionPeriod.toMillis))
@@ -54,7 +54,7 @@ private[consumer] object PubsubSubscriber {
         val service = sub.startAsync()
         val shutdown =
           F.delay(
-              service.stopAsync().awaitTerminated(config.awaitTerminatePeriod.toSeconds, TimeUnit.SECONDS),
+              service.stopAsync().awaitTerminated(config.awaitTerminatePeriod.toSeconds, TimeUnit.SECONDS)
             )
             .handleErrorWith(config.onFailedTerminate)
 
@@ -65,10 +65,10 @@ private[consumer] object PubsubSubscriber {
   def subscribe[F[_]](
     projectId: PublicModel.ProjectId,
     subscription: PublicModel.Subscription,
-    config: PubsubGoogleConsumerConfig[F],
+    config: PubsubGoogleConsumerConfig[F]
   )(
     implicit F: Concurrent[F],
-    CX: ContextShift[F],
+    CX: ContextShift[F]
   ): Stream[F, Model.Record[F]] =
     for {
       pool  <- Stream.resource(ThreadPool.blockingThreadPool(config.parallelPullCount))

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/GooglePubsubProducer.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/GooglePubsubProducer.scala
@@ -8,14 +8,13 @@ import com.permutive.pubsub.producer.encoder.MessageEncoder
 import com.permutive.pubsub.producer.grpc.internal.{DefaultPublisher, PubsubPublisher}
 
 object GooglePubsubProducer {
-  def of[F[_] : Async, A: MessageEncoder](
+  def of[F[_]: Async, A: MessageEncoder](
     projectId: ProjectId,
     topic: Topic,
     config: PubsubProducerConfig[F],
-  ): Resource[F, PubsubProducer[F, A]] = {
+  ): Resource[F, PubsubProducer[F, A]] =
     for {
       publisher <- PubsubPublisher.createJavaPublisher(projectId, topic, config)
       executor  <- JavaExecutor.fixedThreadPool(config.callbackExecutors)
     } yield new DefaultPublisher(publisher, executor)
-  }
 }

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/GooglePubsubProducer.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/GooglePubsubProducer.scala
@@ -11,7 +11,7 @@ object GooglePubsubProducer {
   def of[F[_]: Async, A: MessageEncoder](
     projectId: ProjectId,
     topic: Topic,
-    config: PubsubProducerConfig[F],
+    config: PubsubProducerConfig[F]
   ): Resource[F, PubsubProducer[F, A]] =
     for {
       publisher <- PubsubPublisher.createJavaPublisher(projectId, topic, config)

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/PubsubProducerConfig.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/PubsubProducerConfig.scala
@@ -5,19 +5,14 @@ import com.google.cloud.pubsub.v1.Publisher
 import scala.concurrent.duration._
 
 case class PubsubProducerConfig[F[_]](
-
   batchSize: Long,
   delayThreshold: FiniteDuration,
-
   requestByteThreshold: Option[Long] = None,
-
   averageMessageSize: Long = 1024, // 1kB
 
   callbackExecutors: Int = Runtime.getRuntime.availableProcessors() * 3,
-
   // modify publisher
   customizePublisher: Option[Publisher.Builder => Publisher.Builder] = None,
-
   // termination
   awaitTerminatePeriod: FiniteDuration = 30.seconds,
   onFailedTerminate: Throwable => F[Unit],

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/PubsubProducerConfig.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/PubsubProducerConfig.scala
@@ -15,5 +15,5 @@ case class PubsubProducerConfig[F[_]](
   customizePublisher: Option[Publisher.Builder => Publisher.Builder] = None,
   // termination
   awaitTerminatePeriod: FiniteDuration = 30.seconds,
-  onFailedTerminate: Throwable => F[Unit],
+  onFailedTerminate: Throwable => F[Unit]
 )

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/internal/DefaultPublisher.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/internal/DefaultPublisher.scala
@@ -18,14 +18,14 @@ import scala.collection.JavaConverters._
 
 private[pubsub] class DefaultPublisher[F[_], A: MessageEncoder](
   publisher: Publisher,
-  callbackExecutor: Executor,
+  callbackExecutor: Executor
 )(
-  implicit F: Async[F],
+  implicit F: Async[F]
 ) extends PubsubProducer[F, A] {
   final override def produce(
     record: A,
     metadata: Map[String, String] = Map.empty,
-    uniqueId: String = UUID.randomUUID.toString,
+    uniqueId: String = UUID.randomUUID.toString
   ): F[MessageId] =
     MessageEncoder[A].encode(record) match {
       case Left(e) =>
@@ -47,7 +47,7 @@ private[pubsub] class DefaultPublisher[F[_], A: MessageEncoder](
                 override def onFailure(t: Throwable): Unit   = cb(Left(t))
                 override def onSuccess(result: String): Unit = cb(Right(MessageId(result)))
               },
-              callbackExecutor,
+              callbackExecutor
             )
           }
         } yield result

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/internal/PubsubPublisher.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/internal/PubsubPublisher.scala
@@ -17,8 +17,8 @@ private[producer] object PubsubPublisher {
     topic: Topic,
     config: PubsubProducerConfig[F],
   )(
-    implicit F: Sync[F]
-  ): Resource[F, Publisher] = {
+    implicit F: Sync[F],
+  ): Resource[F, Publisher] =
     Resource[F, Publisher] {
       F.delay {
         val publisherBuilder =
@@ -28,14 +28,15 @@ private[producer] object PubsubPublisher {
               BatchingSettings
                 .newBuilder()
                 .setElementCountThreshold(config.batchSize)
-                .setRequestByteThreshold(config.requestByteThreshold.getOrElse[Long](config.batchSize * config.averageMessageSize * 2L))
+                .setRequestByteThreshold(
+                  config.requestByteThreshold.getOrElse[Long](config.batchSize * config.averageMessageSize * 2L),
+                )
                 .setDelayThreshold(Duration.ofMillis(config.delayThreshold.toMillis))
-                .build()
+                .build(),
             )
 
         val publisher =
-          config
-            .customizePublisher
+          config.customizePublisher
             .map(f => f(publisherBuilder))
             .getOrElse(publisherBuilder)
             .build()
@@ -49,5 +50,4 @@ private[producer] object PubsubPublisher {
         (publisher, shutdown)
       }
     }
-  }
 }

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/internal/PubsubPublisher.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/internal/PubsubPublisher.scala
@@ -15,9 +15,9 @@ private[producer] object PubsubPublisher {
   def createJavaPublisher[F[_]](
     projectId: ProjectId,
     topic: Topic,
-    config: PubsubProducerConfig[F],
+    config: PubsubProducerConfig[F]
   )(
-    implicit F: Sync[F],
+    implicit F: Sync[F]
   ): Resource[F, Publisher] =
     Resource[F, Publisher] {
       F.delay {
@@ -29,10 +29,10 @@ private[producer] object PubsubPublisher {
                 .newBuilder()
                 .setElementCountThreshold(config.batchSize)
                 .setRequestByteThreshold(
-                  config.requestByteThreshold.getOrElse[Long](config.batchSize * config.averageMessageSize * 2L),
+                  config.requestByteThreshold.getOrElse[Long](config.batchSize * config.averageMessageSize * 2L)
                 )
                 .setDelayThreshold(Duration.ofMillis(config.delayThreshold.toMillis))
-                .build(),
+                .build()
             )
 
         val publisher =

--- a/fs2-google-pubsub-grpc/src/test/scala/com/permutive/pubsub/consumer/grpc/SimpleDriver.scala
+++ b/fs2-google-pubsub-grpc/src/test/scala/com/permutive/pubsub/consumer/grpc/SimpleDriver.scala
@@ -9,7 +9,7 @@ object SimpleDriver extends IOApp {
   case class ValueHolder(value: String) extends AnyVal
 
   implicit val decoder: MessageDecoder[ValueHolder] = (bytes: Array[Byte]) => {
-    Right(ValueHolder(new String(bytes))),
+    Right(ValueHolder(new String(bytes)))
   }
 
   override def run(args: List[String]): IO[ExitCode] = {
@@ -18,8 +18,8 @@ object SimpleDriver extends IOApp {
       Model.Subscription("example-sub"),
       (msg, err, ack, _) => IO(println(s"Msg $msg got error $err")) >> ack,
       config = PubsubGoogleConsumerConfig(
-        onFailedTerminate = _ => IO.unit,
-      ),
+        onFailedTerminate = _ => IO.unit
+      )
     )
 
     stream

--- a/fs2-google-pubsub-grpc/src/test/scala/com/permutive/pubsub/consumer/grpc/SimpleDriver.scala
+++ b/fs2-google-pubsub-grpc/src/test/scala/com/permutive/pubsub/consumer/grpc/SimpleDriver.scala
@@ -9,7 +9,7 @@ object SimpleDriver extends IOApp {
   case class ValueHolder(value: String) extends AnyVal
 
   implicit val decoder: MessageDecoder[ValueHolder] = (bytes: Array[Byte]) => {
-    Right(ValueHolder(new String(bytes)))
+    Right(ValueHolder(new String(bytes))),
   }
 
   override def run(args: List[String]): IO[ExitCode] = {
@@ -18,8 +18,8 @@ object SimpleDriver extends IOApp {
       Model.Subscription("example-sub"),
       (msg, err, ack, _) => IO(println(s"Msg $msg got error $err")) >> ack,
       config = PubsubGoogleConsumerConfig(
-        onFailedTerminate = _ => IO.unit
-      )
+        onFailedTerminate = _ => IO.unit,
+      ),
     )
 
     stream

--- a/fs2-google-pubsub-grpc/src/test/scala/com/permutive/pubsub/producer/grpc/PubsubProducerExample.scala
+++ b/fs2-google-pubsub-grpc/src/test/scala/com/permutive/pubsub/producer/grpc/PubsubProducerExample.scala
@@ -16,19 +16,21 @@ object PubsubProducerExample extends IOApp {
       Right(BigInt(a.v).toByteArray)
   }
 
-  override def run(args: List[String]): IO[ExitCode] = {
-    GooglePubsubProducer.of[IO, Value](
-      Model.ProjectId("test-project"),
-      Model.Topic("values"),
-      config = PubsubProducerConfig[IO](
-        batchSize = 100,
-        delayThreshold = 100.millis,
-        onFailedTerminate = e => IO(println(s"Got error $e")) >> IO.unit
+  override def run(args: List[String]): IO[ExitCode] =
+    GooglePubsubProducer
+      .of[IO, Value](
+        Model.ProjectId("test-project"),
+        Model.Topic("values"),
+        config = PubsubProducerConfig[IO](
+          batchSize = 100,
+          delayThreshold = 100.millis,
+          onFailedTerminate = e => IO(println(s"Got error $e")) >> IO.unit,
+        ),
       )
-    ).use { producer =>
-      producer.produce(
-        Value(10),
-      )
-    }.map(_ => ExitCode.Success)
-  }
+      .use { producer =>
+        producer.produce(
+          Value(10),
+        )
+      }
+      .map(_ => ExitCode.Success)
 }

--- a/fs2-google-pubsub-grpc/src/test/scala/com/permutive/pubsub/producer/grpc/PubsubProducerExample.scala
+++ b/fs2-google-pubsub-grpc/src/test/scala/com/permutive/pubsub/producer/grpc/PubsubProducerExample.scala
@@ -24,12 +24,12 @@ object PubsubProducerExample extends IOApp {
         config = PubsubProducerConfig[IO](
           batchSize = 100,
           delayThreshold = 100.millis,
-          onFailedTerminate = e => IO(println(s"Got error $e")) >> IO.unit,
-        ),
+          onFailedTerminate = e => IO(println(s"Got error $e")) >> IO.unit
+        )
       )
       .use { producer =>
         producer.produce(
-          Value(10),
+          Value(10)
         )
       }
       .map(_ => ExitCode.Success)

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubHttpConsumer.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubHttpConsumer.scala
@@ -28,7 +28,7 @@ object PubsubHttpConsumer {
     serviceAccountPath: String,
     config: PubsubHttpConsumerConfig[F],
     httpClient: Client[F],
-    errorHandler: (PubsubMessage, Throwable, F[Unit], F[Unit]) => F[Unit],
+    errorHandler: (PubsubMessage, Throwable, F[Unit], F[Unit]) => F[Unit]
   ): Stream[F, Model.Record[F, A]] =
     PubsubSubscriber
       .subscribe(projectId, subscription, serviceAccountPath, config, httpClient)
@@ -54,7 +54,7 @@ object PubsubHttpConsumer {
     serviceAccountPath: String,
     config: PubsubHttpConsumerConfig[F],
     httpClient: Client[F],
-    errorHandler: (PubsubMessage, Throwable, F[Unit], F[Unit]) => F[Unit],
+    errorHandler: (PubsubMessage, Throwable, F[Unit], F[Unit]) => F[Unit]
   ): Stream[F, A] =
     PubsubSubscriber
       .subscribe(projectId, subscription, serviceAccountPath, config, httpClient)
@@ -74,7 +74,7 @@ object PubsubHttpConsumer {
     subscription: Subscription,
     serviceAccountPath: String,
     config: PubsubHttpConsumerConfig[F],
-    httpClient: Client[F],
+    httpClient: Client[F]
   ): Stream[F, Model.Record[F, PubsubMessage]] =
     PubsubSubscriber
       .subscribe(projectId, subscription, serviceAccountPath, config, httpClient)

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubHttpConsumerConfig.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubHttpConsumerConfig.scala
@@ -6,13 +6,10 @@ case class PubsubHttpConsumerConfig[F[_]](
   host: String = "pubsub.googleapis.com",
   port: Int = 443,
   isEmulator: Boolean = false,
-
   oauthTokenRefreshInterval: FiniteDuration = 30.minutes,
   onTokenRefreshError: PartialFunction[Throwable, F[Unit]] = PartialFunction.empty,
-
   acknowledgeBatchSize: Int = 100,
   acknowledgeBatchLatency: FiniteDuration = 1.second,
-
   readReturnImmediately: Boolean = false,
   readMaxMessages: Int = 1000,
   readConcurrency: Int = 1,

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubHttpConsumerConfig.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubHttpConsumerConfig.scala
@@ -12,5 +12,5 @@ case class PubsubHttpConsumerConfig[F[_]](
   acknowledgeBatchLatency: FiniteDuration = 1.second,
   readReturnImmediately: Boolean = false,
   readMaxMessages: Int = 1000,
-  readConcurrency: Int = 1,
+  readConcurrency: Int = 1
 )

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubMessage.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubMessage.scala
@@ -7,7 +7,7 @@ case class PubsubMessage(
   data: String,
   attributes: Map[String, String],
   messageId: String,
-  publishTime: String,
+  publishTime: String
 )
 
 object PubsubMessage {

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubMessage.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubMessage.scala
@@ -11,6 +11,6 @@ case class PubsubMessage(
 )
 
 object PubsubMessage {
-  final implicit val Codec: JsonValueCodec[PubsubMessage] =
+  implicit final val Codec: JsonValueCodec[PubsubMessage] =
     JsonCodecMaker.make[PubsubMessage](CodecMakerConfig())
 }

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/HttpPubsubReader.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/HttpPubsubReader.scala
@@ -13,7 +13,7 @@ import com.permutive.pubsub.consumer.http.internal.Model.{
   NackRequest,
   ProjectNameSubscription,
   PullRequest,
-  PullResponse,
+  PullResponse
 }
 import com.permutive.pubsub.http.oauth.{AccessToken, DefaultTokenProvider}
 import com.permutive.pubsub.http.util.RefreshableRef
@@ -32,9 +32,9 @@ private[internal] class HttpPubsubReader[F[_]] private (
   client: Client[F],
   tokenRef: Ref[F, AccessToken],
   returnImmediately: Boolean,
-  maxMessages: Int,
+  maxMessages: Int
 )(
-  implicit F: Sync[F],
+  implicit F: Sync[F]
 ) extends PubsubReader[F] {
   object dsl extends Http4sClientDsl[F]
 
@@ -54,15 +54,15 @@ private[internal] class HttpPubsubReader[F[_]] private (
         writeToArray(
           PullRequest(
             returnImmediately = returnImmediately,
-            maxMessages = maxMessages,
-          ),
-        ),
+            maxMessages = maxMessages
+          )
+        )
       )
       token <- tokenRef.get
       req <- POST(
         json,
         pullEndpoint.withQueryParam("access_token", token.accessToken),
-        `Content-Type`(MediaType.application.json),
+        `Content-Type`(MediaType.application.json)
       )
       resp <- client.expectOr[Array[Byte]](req)(onError)
       resp <- F.delay(readFromArray[PullResponse](resp))
@@ -74,15 +74,15 @@ private[internal] class HttpPubsubReader[F[_]] private (
       json <- F.delay(
         writeToArray(
           AckRequest(
-            ackIds = ackIds,
-          ),
-        ),
+            ackIds = ackIds
+          )
+        )
       )
       token <- tokenRef.get
       req <- POST(
         json,
         acknowledgeEndpoint.withQueryParam("access_token", token.accessToken),
-        `Content-Type`(MediaType.application.json),
+        `Content-Type`(MediaType.application.json)
       )
       _ <- client.expectOr[Array[Byte]](req)(onError)
     } yield ()
@@ -93,15 +93,15 @@ private[internal] class HttpPubsubReader[F[_]] private (
         writeToArray(
           NackRequest(
             ackIds = ackIds,
-            ackDeadlineSeconds = 0,
-          ),
-        ),
+            ackDeadlineSeconds = 0
+          )
+        )
       )
       token <- tokenRef.get
       req <- POST(
         json,
         nackEndpoint.withQueryParam("access_token", token.accessToken),
-        `Content-Type`(MediaType.application.json),
+        `Content-Type`(MediaType.application.json)
       )
       _ <- client.expectOr[Array[Byte]](req)(onError)
     } yield ()
@@ -117,31 +117,31 @@ private[internal] object HttpPubsubReader {
     subscription: Subscription,
     serviceAccountPath: String,
     config: PubsubHttpConsumerConfig[F],
-    httpClient: Client[F],
+    httpClient: Client[F]
   ): Resource[F, PubsubReader[F]] =
     for {
       tokenProvider <- Resource.liftF(
         if (config.isEmulator) DefaultTokenProvider.noAuth.pure
-        else DefaultTokenProvider.google(serviceAccountPath, httpClient),
+        else DefaultTokenProvider.google(serviceAccountPath, httpClient)
       )
       accessTokenRef <- RefreshableRef.resource(
         refresh = tokenProvider.accessToken,
         refreshInterval = config.oauthTokenRefreshInterval,
-        onRefreshError = config.onTokenRefreshError,
+        onRefreshError = config.onTokenRefreshError
       )
     } yield new HttpPubsubReader(
       baseApiUrl = createBaseApi(config, ProjectNameSubscription.of(projectId, subscription)),
       client = httpClient,
       tokenRef = accessTokenRef.ref,
       returnImmediately = config.readReturnImmediately,
-      maxMessages = config.readMaxMessages,
+      maxMessages = config.readMaxMessages
     )
 
   def createBaseApi[F[_]](config: PubsubHttpConsumerConfig[F], projectNameSubscription: ProjectNameSubscription): Uri =
     Uri(
       scheme = Option(if (config.port == 443) Uri.Scheme.https else Uri.Scheme.http),
       authority = Option(Uri.Authority(host = RegName(config.host), port = Option(config.port))),
-      path = s"/v1/${projectNameSubscription.value}",
+      path = s"/v1/${projectNameSubscription.value}"
     )
 
   sealed abstract class PubSubError(msg: String)

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/Model.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/Model.scala
@@ -8,22 +8,21 @@ import com.permutive.pubsub.consumer.{Model => PublicModel}
 private[http] object Model {
   case class ProjectNameSubscription(value: String) extends AnyVal
   object ProjectNameSubscription {
-    def of(projectId: PublicModel.ProjectId, subscription: PublicModel.Subscription): ProjectNameSubscription = {
+    def of(projectId: PublicModel.ProjectId, subscription: PublicModel.Subscription): ProjectNameSubscription =
       ProjectNameSubscription(s"projects/${projectId.value}/subscriptions/${subscription.value}")
-    }
   }
   case class Record[F[_]](value: PubsubMessage, ack: F[Unit], nack: F[Unit])
 
-  final implicit val PullRequestCodec: JsonValueCodec[PullRequest] =
+  implicit final val PullRequestCodec: JsonValueCodec[PullRequest] =
     JsonCodecMaker.make[PullRequest](CodecMakerConfig())
 
-  final implicit val PullResponseCodec: JsonValueCodec[PullResponse] =
+  implicit final val PullResponseCodec: JsonValueCodec[PullResponse] =
     JsonCodecMaker.make[PullResponse](CodecMakerConfig())
 
-  final implicit val AckRequestCodec: JsonValueCodec[AckRequest] =
+  implicit final val AckRequestCodec: JsonValueCodec[AckRequest] =
     JsonCodecMaker.make[AckRequest](CodecMakerConfig())
 
-  final implicit val NackRequestCodec: JsonValueCodec[NackRequest] =
+  implicit final val NackRequestCodec: JsonValueCodec[NackRequest] =
     JsonCodecMaker.make[NackRequest](CodecMakerConfig())
 
   case class AckId(value: String) extends AnyVal
@@ -43,7 +42,7 @@ private[http] object Model {
   )
 
   case class AckRequest(
-    ackIds: List[AckId]
+    ackIds: List[AckId],
   )
 
   case class NackRequest(

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/Model.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/Model.scala
@@ -29,24 +29,24 @@ private[http] object Model {
 
   case class PullRequest(
     returnImmediately: Boolean,
-    maxMessages: Int,
+    maxMessages: Int
   )
 
   case class PullResponse(
-    receivedMessages: List[ReceivedMessage],
+    receivedMessages: List[ReceivedMessage]
   )
 
   case class ReceivedMessage(
     ackId: AckId,
-    message: PubsubMessage,
+    message: PubsubMessage
   )
 
   case class AckRequest(
-    ackIds: List[AckId],
+    ackIds: List[AckId]
   )
 
   case class NackRequest(
     ackIds: List[AckId],
-    ackDeadlineSeconds: Int,
+    ackDeadlineSeconds: Int
   )
 }

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/crypto/GoogleAccountParser.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/crypto/GoogleAccountParser.scala
@@ -19,15 +19,15 @@ object GoogleAccountParser {
     privateKeyId: String,
     privateKey: String,
     clientEmail: String,
-    authUri: String,
+    authUri: String
   )
 
   object JsonGoogleServiceAccount {
     implicit final val codec: JsonValueCodec[JsonGoogleServiceAccount] =
       JsonCodecMaker.make[JsonGoogleServiceAccount](
         CodecMakerConfig(
-          fieldNameMapper = JsonCodecMaker.enforce_snake_case,
-        ),
+          fieldNameMapper = JsonCodecMaker.enforce_snake_case
+        )
       )
   }
 
@@ -38,7 +38,7 @@ object GoogleAccountParser {
       val kf             = KeyFactory.getInstance("RSA")
       GoogleServiceAccount(
         clientEmail = serviceAccount.clientEmail,
-        privateKey = kf.generatePrivate(spec).asInstanceOf[RSAPrivateKey],
+        privateKey = kf.generatePrivate(spec).asInstanceOf[RSAPrivateKey]
       )
     }.toEither
 

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/crypto/GoogleAccountParser.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/crypto/GoogleAccountParser.scala
@@ -23,25 +23,26 @@ object GoogleAccountParser {
   )
 
   object JsonGoogleServiceAccount {
-    final implicit val codec: JsonValueCodec[JsonGoogleServiceAccount] =
-      JsonCodecMaker.make[JsonGoogleServiceAccount](CodecMakerConfig(
-        fieldNameMapper = JsonCodecMaker.enforce_snake_case
-      ))
+    implicit final val codec: JsonValueCodec[JsonGoogleServiceAccount] =
+      JsonCodecMaker.make[JsonGoogleServiceAccount](
+        CodecMakerConfig(
+          fieldNameMapper = JsonCodecMaker.enforce_snake_case,
+        ),
+      )
   }
 
-  final def parse(path: Path): Either[Throwable, GoogleServiceAccount] = {
+  final def parse(path: Path): Either[Throwable, GoogleServiceAccount] =
     Try {
       val serviceAccount = readFromArray[JsonGoogleServiceAccount](Files.readAllBytes(path))
-      val spec = new PKCS8EncodedKeySpec(loadPem(serviceAccount.privateKey))
-      val kf = KeyFactory.getInstance("RSA")
+      val spec           = new PKCS8EncodedKeySpec(loadPem(serviceAccount.privateKey))
+      val kf             = KeyFactory.getInstance("RSA")
       GoogleServiceAccount(
         clientEmail = serviceAccount.clientEmail,
-        privateKey = kf.generatePrivate(spec).asInstanceOf[RSAPrivateKey]
+        privateKey = kf.generatePrivate(spec).asInstanceOf[RSAPrivateKey],
       )
     }.toEither
-  }
 
-  private[this] final val privateKeyPattern = Pattern.compile("(?m)(?s)^---*BEGIN.*---*$(.*)^---*END.*---*$.*")
+  final private[this] val privateKeyPattern = Pattern.compile("(?m)(?s)^---*BEGIN.*---*$(.*)^---*END.*---*$.*")
 
   private def loadPem(pem: String): Array[Byte] = {
     val encoded = privateKeyPattern.matcher(pem).replaceFirst("$1")

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/AccessToken.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/AccessToken.scala
@@ -6,8 +6,10 @@ import com.github.plokhotnyuk.jsoniter_scala.macros._
 final case class AccessToken(accessToken: String, tokenType: String, expiresIn: Int)
 
 object AccessToken {
-  final implicit val codec: JsonValueCodec[AccessToken] =
-    JsonCodecMaker.make[AccessToken](CodecMakerConfig(
-      fieldNameMapper = JsonCodecMaker.enforce_snake_case
-    ))
+  implicit final val codec: JsonValueCodec[AccessToken] =
+    JsonCodecMaker.make[AccessToken](
+      CodecMakerConfig(
+        fieldNameMapper = JsonCodecMaker.enforce_snake_case,
+      ),
+    )
 }

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/AccessToken.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/AccessToken.scala
@@ -9,7 +9,7 @@ object AccessToken {
   implicit final val codec: JsonValueCodec[AccessToken] =
     JsonCodecMaker.make[AccessToken](
       CodecMakerConfig(
-        fieldNameMapper = JsonCodecMaker.enforce_snake_case,
-      ),
+        fieldNameMapper = JsonCodecMaker.enforce_snake_case
+      )
     )
 }

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/DefaultTokenProvider.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/DefaultTokenProvider.scala
@@ -12,9 +12,9 @@ import org.http4s.client.Client
 class DefaultTokenProvider[F[_]](
   emailAddress: String,
   scope: List[String],
-  auth: OAuth[F],
+  auth: OAuth[F]
 )(
-  implicit F: Sync[F],
+  implicit F: Sync[F]
 ) extends TokenProvider[F] {
   override val accessToken: F[AccessToken] = {
     for {
@@ -23,7 +23,7 @@ class DefaultTokenProvider[F[_]](
         emailAddress,
         scope.mkString(","),
         now.plusMillis(auth.maxDuration.toMillis),
-        now,
+        now
       )
       tokenOrError <- token.fold(F.raiseError[AccessToken](TokenProvider.FailedToGetToken))(_.pure[F])
     } yield tokenOrError
@@ -33,18 +33,18 @@ class DefaultTokenProvider[F[_]](
 object DefaultTokenProvider {
   def google[F[_]: Logger](
     serviceAccountPath: String,
-    httpClient: Client[F],
+    httpClient: Client[F]
   )(
-    implicit F: Concurrent[F],
+    implicit F: Concurrent[F]
   ): F[DefaultTokenProvider[F]] =
     for {
       serviceAccount <- F.fromEither(
-        GoogleAccountParser.parse(new File(serviceAccountPath).toPath),
+        GoogleAccountParser.parse(new File(serviceAccountPath).toPath)
       )
     } yield new DefaultTokenProvider(
       serviceAccount.clientEmail,
       List("https://www.googleapis.com/auth/pubsub"),
-      new GoogleOAuth(serviceAccount.privateKey, httpClient),
+      new GoogleOAuth(serviceAccount.privateKey, httpClient)
     )
 
   def noAuth[F[_]: Sync]: DefaultTokenProvider[F] =

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/GoogleOAuth.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/GoogleOAuth.scala
@@ -20,9 +20,9 @@ import scala.util.control.NoStackTrace
 
 class GoogleOAuth[F[_]: Logger](
   key: RSAPrivateKey,
-  httpClient: Client[F],
+  httpClient: Client[F]
 )(
-  implicit F: Sync[F],
+  implicit F: Sync[F]
 ) extends OAuth[F] {
   import GoogleOAuth._
 
@@ -37,7 +37,7 @@ class GoogleOAuth[F[_]: Logger](
     iss: String,
     scope: String,
     exp: Instant,
-    iat: Instant,
+    iat: Instant
   ): F[Option[AccessToken]] = {
     val tokenF = F.delay(
       JWT.create
@@ -46,7 +46,7 @@ class GoogleOAuth[F[_]: Logger](
         .withAudience(googleOAuthDomainStr)
         .withClaim("scope", scope)
         .withClaim("iss", iss)
-        .sign(algorithm),
+        .sign(algorithm)
     )
 
     val request =
@@ -54,7 +54,7 @@ class GoogleOAuth[F[_]: Logger](
         token <- tokenF
         form = UrlForm(
           "grant_type" -> "urn:ietf:params:oauth:grant-type:jwt-bearer",
-          "assertion"  -> token,
+          "assertion"  -> token
         )
         req <- POST(form, googleOAuthDomain)
       } yield req

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/OAuth.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/OAuth.scala
@@ -5,6 +5,7 @@ import java.time.Instant
 import scala.concurrent.duration.FiniteDuration
 
 trait OAuth[F[_]] {
+
   /**
     * Based on https://developers.google.com/identity/protocols/OAuth2ServiceAccount
     * @param iss The email address of the service account.
@@ -16,7 +17,7 @@ trait OAuth[F[_]] {
     iss: String,
     scope: String,
     exp: Instant = Instant.now().plusMillis(maxDuration.toMillis),
-    iat: Instant = Instant.now()
+    iat: Instant = Instant.now(),
   ): F[Option[AccessToken]]
 
   def maxDuration: FiniteDuration

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/OAuth.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/OAuth.scala
@@ -17,7 +17,7 @@ trait OAuth[F[_]] {
     iss: String,
     scope: String,
     exp: Instant = Instant.now().plusMillis(maxDuration.toMillis),
-    iat: Instant = Instant.now(),
+    iat: Instant = Instant.now()
   ): F[Option[AccessToken]]
 
   def maxDuration: FiniteDuration

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/TokenProvider.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/TokenProvider.scala
@@ -8,14 +8,8 @@ trait TokenProvider[F[_]] {
 
 object TokenProvider {
   case object TokenValidityTooLong
-    extends RuntimeException("Valid for duration cannot be longer than maximum of the OAuth provider")
+      extends RuntimeException("Valid for duration cannot be longer than maximum of the OAuth provider")
       with NoStackTrace
 
-  case object FailedToGetToken
-    extends RuntimeException("Failed to get token after many attempts")
+  case object FailedToGetToken extends RuntimeException("Failed to get token after many attempts")
 }
-
-
-
-
-

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/util/RefreshableRef.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/util/RefreshableRef.scala
@@ -15,7 +15,7 @@ object RefreshableRef {
   def create[F[_]: Concurrent: Timer, A](
     refresh: F[A],
     refreshInterval: FiniteDuration,
-    onRefreshError: PartialFunction[Throwable, F[Unit]],
+    onRefreshError: PartialFunction[Throwable, F[Unit]]
   ): F[RefreshableRef[F, A]] =
     for {
       initial <- refresh
@@ -26,7 +26,7 @@ object RefreshableRef {
   def resource[F[_]: Concurrent: Timer, A](
     refresh: F[A],
     refreshInterval: FiniteDuration,
-    onRefreshError: PartialFunction[Throwable, F[Unit]],
+    onRefreshError: PartialFunction[Throwable, F[Unit]]
   ): Resource[F, RefreshableRef[F, A]] =
     Resource.make(create(refresh, refreshInterval, onRefreshError))(refreshableRef => refreshableRef.cancelToken)
 
@@ -34,7 +34,7 @@ object RefreshableRef {
     refresh: F[A],
     ref: Ref[F, A],
     refreshInterval: FiniteDuration,
-    onRefreshError: PartialFunction[Throwable, F[Unit]],
+    onRefreshError: PartialFunction[Throwable, F[Unit]]
   ): F[Unit] = {
     def update(refresh: F[A], ref: Ref[F, A]): F[Unit] =
       for {
@@ -46,7 +46,7 @@ object RefreshableRef {
       refresh,
       ref,
       refreshInterval,
-      onRefreshError,
+      onRefreshError
     )
   }
 }

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/util/RefreshableRef.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/util/RefreshableRef.scala
@@ -12,38 +12,41 @@ import scala.concurrent.duration.FiniteDuration
 case class RefreshableRef[F[_], A](ref: Ref[F, A], cancelToken: F[Unit])
 
 object RefreshableRef {
-
-  def create[F[_] : Concurrent : Timer, A](
+  def create[F[_]: Concurrent: Timer, A](
     refresh: F[A],
     refreshInterval: FiniteDuration,
-    onRefreshError: PartialFunction[Throwable, F[Unit]]
-  ): F[RefreshableRef[F, A]] = for {
-    initial <- refresh
-    ref     <- Ref.of(initial)
-    fiber   <- updateLoop(refresh, ref, refreshInterval, onRefreshError).start
-  } yield RefreshableRef(ref, fiber.cancel)
+    onRefreshError: PartialFunction[Throwable, F[Unit]],
+  ): F[RefreshableRef[F, A]] =
+    for {
+      initial <- refresh
+      ref     <- Ref.of(initial)
+      fiber   <- updateLoop(refresh, ref, refreshInterval, onRefreshError).start
+    } yield RefreshableRef(ref, fiber.cancel)
 
-  def resource[F[_] : Concurrent : Timer, A](
+  def resource[F[_]: Concurrent: Timer, A](
     refresh: F[A],
     refreshInterval: FiniteDuration,
-    onRefreshError: PartialFunction[Throwable, F[Unit]]
+    onRefreshError: PartialFunction[Throwable, F[Unit]],
   ): Resource[F, RefreshableRef[F, A]] =
     Resource.make(create(refresh, refreshInterval, onRefreshError))(refreshableRef => refreshableRef.cancelToken)
 
-  private def updateLoop[F[_] : Sync : Timer, A](
+  private def updateLoop[F[_]: Sync: Timer, A](
     refresh: F[A],
     ref: Ref[F, A],
     refreshInterval: FiniteDuration,
-    onRefreshError: PartialFunction[Throwable, F[Unit]]
+    onRefreshError: PartialFunction[Throwable, F[Unit]],
   ): F[Unit] = {
-    def update(refresh: F[A], ref: Ref[F, A]): F[Unit] = {
+    def update(refresh: F[A], ref: Ref[F, A]): F[Unit] =
       for {
         value <- refresh
         _     <- ref.update(_ => value)
       } yield ()
-    }
 
-    Timer[F].sleep(refreshInterval) >> update(refresh, ref).recoverWith(onRefreshError) >> updateLoop(refresh, ref, refreshInterval, onRefreshError)
+    Timer[F].sleep(refreshInterval) >> update(refresh, ref).recoverWith(onRefreshError) >> updateLoop(
+      refresh,
+      ref,
+      refreshInterval,
+      onRefreshError,
+    )
   }
-
 }

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/BatchingHttpProducerConfig.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/BatchingHttpProducerConfig.scala
@@ -7,5 +7,5 @@ case class BatchingHttpProducerConfig(
   maxLatency: FiniteDuration,
   retryTimes: Int,
   retryInitialDelay: FiniteDuration,
-  retryNextDelay: FiniteDuration => FiniteDuration,
+  retryNextDelay: FiniteDuration => FiniteDuration
 )

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/BatchingHttpProducerConfig.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/BatchingHttpProducerConfig.scala
@@ -5,7 +5,6 @@ import scala.concurrent.duration.FiniteDuration
 case class BatchingHttpProducerConfig(
   batchSize: Int,
   maxLatency: FiniteDuration,
-
   retryTimes: Int,
   retryInitialDelay: FiniteDuration,
   retryNextDelay: FiniteDuration => FiniteDuration,

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/BatchingHttpPubsubProducer.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/BatchingHttpPubsubProducer.scala
@@ -14,7 +14,7 @@ object BatchingHttpPubsubProducer {
     googleServiceAccountPath: String,
     config: PubsubHttpProducerConfig[F],
     batchingConfig: BatchingHttpProducerConfig,
-    httpClient: Client[F],
+    httpClient: Client[F]
   ): Resource[F, AsyncPubsubProducer[F, A]] =
     for {
       publisher <- DefaultHttpPublisher.resource(
@@ -22,11 +22,11 @@ object BatchingHttpPubsubProducer {
         topic = topic,
         serviceAccountPath = googleServiceAccountPath,
         config = config,
-        httpClient = httpClient,
+        httpClient = httpClient
       )
       batching <- BatchingHttpPublisher.resource(
         publisher = publisher,
-        config = batchingConfig,
+        config = batchingConfig
       )
     } yield batching
 }

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/BatchingHttpPubsubProducer.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/BatchingHttpPubsubProducer.scala
@@ -8,26 +8,25 @@ import io.chrisdavenport.log4cats.Logger
 import org.http4s.client.Client
 
 object BatchingHttpPubsubProducer {
-  def resource[F[_] : Concurrent : Timer : Logger, A: MessageEncoder](
+  def resource[F[_]: Concurrent: Timer: Logger, A: MessageEncoder](
     projectId: Model.ProjectId,
     topic: Model.Topic,
     googleServiceAccountPath: String,
     config: PubsubHttpProducerConfig[F],
     batchingConfig: BatchingHttpProducerConfig,
     httpClient: Client[F],
-  ): Resource[F, AsyncPubsubProducer[F, A]] = {
+  ): Resource[F, AsyncPubsubProducer[F, A]] =
     for {
       publisher <- DefaultHttpPublisher.resource(
         projectId = projectId,
         topic = topic,
         serviceAccountPath = googleServiceAccountPath,
         config = config,
-        httpClient = httpClient
+        httpClient = httpClient,
       )
       batching <- BatchingHttpPublisher.resource(
         publisher = publisher,
         config = batchingConfig,
       )
     } yield batching
-  }
 }

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/HttpPubsubProducer.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/HttpPubsubProducer.scala
@@ -13,13 +13,13 @@ object HttpPubsubProducer {
     topic: Model.Topic,
     googleServiceAccountPath: String,
     config: PubsubHttpProducerConfig[F],
-    httpClient: Client[F],
+    httpClient: Client[F]
   ): Resource[F, PubsubProducer[F, A]] =
     DefaultHttpPublisher.resource(
       projectId = projectId,
       topic = topic,
       serviceAccountPath = googleServiceAccountPath,
       config = config,
-      httpClient = httpClient,
+      httpClient = httpClient
     )
 }

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/HttpPubsubProducer.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/HttpPubsubProducer.scala
@@ -8,19 +8,18 @@ import io.chrisdavenport.log4cats.Logger
 import org.http4s.client.Client
 
 object HttpPubsubProducer {
-  def resource[F[_] : Concurrent : Timer : Logger, A: MessageEncoder](
+  def resource[F[_]: Concurrent: Timer: Logger, A: MessageEncoder](
     projectId: Model.ProjectId,
     topic: Model.Topic,
     googleServiceAccountPath: String,
     config: PubsubHttpProducerConfig[F],
     httpClient: Client[F],
-  ): Resource[F, PubsubProducer[F, A]] = {
+  ): Resource[F, PubsubProducer[F, A]] =
     DefaultHttpPublisher.resource(
       projectId = projectId,
       topic = topic,
       serviceAccountPath = googleServiceAccountPath,
       config = config,
-      httpClient = httpClient
+      httpClient = httpClient,
     )
-  }
 }

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/PubsubHttpProducerConfig.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/PubsubHttpProducerConfig.scala
@@ -18,10 +18,8 @@ case class PubsubHttpProducerConfig[F[_]](
   host: String = "pubsub.googleapis.com",
   port: Int = 443,
   isEmulator: Boolean = false,
-
   oauthTokenRefreshInterval: FiniteDuration = 30.minutes,
   onTokenRefreshError: PartialFunction[Throwable, F[Unit]] = PartialFunction.empty,
-
   oauthTokenFailureRetryDelay: FiniteDuration = 0.millis,
   oauthTokenFailureRetryNextDelay: FiniteDuration => FiniteDuration = _ => 5.minutes,
   oauthTokenFailureRetryMaxAttempts: Int = Int.MaxValue,

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/PubsubHttpProducerConfig.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/PubsubHttpProducerConfig.scala
@@ -22,5 +22,5 @@ case class PubsubHttpProducerConfig[F[_]](
   onTokenRefreshError: PartialFunction[Throwable, F[Unit]] = PartialFunction.empty,
   oauthTokenFailureRetryDelay: FiniteDuration = 0.millis,
   oauthTokenFailureRetryNextDelay: FiniteDuration => FiniteDuration = _ => 5.minutes,
-  oauthTokenFailureRetryMaxAttempts: Int = Int.MaxValue,
+  oauthTokenFailureRetryMaxAttempts: Int = Int.MaxValue
 )

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/consumer/http/Example.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/consumer/http/Example.scala
@@ -15,14 +15,15 @@ object Example extends IOApp {
   case class ValueHolder(value: String) extends AnyVal
 
   implicit val decoder: MessageDecoder[ValueHolder] = (bytes: Array[Byte]) => {
-    Try(ValueHolder(new String(bytes))).toEither
+    Try(ValueHolder(new String(bytes))).toEither,
   }
 
   override def run(args: List[String]): IO[ExitCode] = {
-    val client = Blocker[IO].flatMap(blocker =>
-      OkHttpBuilder
-        .withDefaultClient[IO](blocker.blockingContext)
-        .flatMap(_.resource)
+    val client = Blocker[IO].flatMap(
+      blocker =>
+        OkHttpBuilder
+          .withDefaultClient[IO](blocker.blockingContext)
+          .flatMap(_.resource),
     )
 
     implicit val unsafeLogger: Logger[IO] = Slf4jLogger.getLoggerFromName("fs2-google-pubsub")
@@ -40,7 +41,8 @@ object Example extends IOApp {
       (msg, err, ack, _) => IO(println(s"Msg $msg got error $err")) >> ack,
     )
 
-    Stream.resource(client)
+    Stream
+      .resource(client)
       .flatMap(mkConsumer)
       .evalTap(t => t.ack >> IO(println(s"Got: ${t.value}")))
       .as(ExitCode.Success)

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/consumer/http/Example.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/consumer/http/Example.scala
@@ -15,7 +15,7 @@ object Example extends IOApp {
   case class ValueHolder(value: String) extends AnyVal
 
   implicit val decoder: MessageDecoder[ValueHolder] = (bytes: Array[Byte]) => {
-    Try(ValueHolder(new String(bytes))).toEither,
+    Try(ValueHolder(new String(bytes))).toEither
   }
 
   override def run(args: List[String]): IO[ExitCode] = {
@@ -23,7 +23,7 @@ object Example extends IOApp {
       blocker =>
         OkHttpBuilder
           .withDefaultClient[IO](blocker.blockingContext)
-          .flatMap(_.resource),
+          .flatMap(_.resource)
     )
 
     implicit val unsafeLogger: Logger[IO] = Slf4jLogger.getLoggerFromName("fs2-google-pubsub")
@@ -35,10 +35,10 @@ object Example extends IOApp {
       PubsubHttpConsumerConfig(
         host = "localhost",
         port = 8085,
-        isEmulator = true,
+        isEmulator = true
       ),
       _,
-      (msg, err, ack, _) => IO(println(s"Msg $msg got error $err")) >> ack,
+      (msg, err, ack, _) => IO(println(s"Msg $msg got error $err")) >> ack
     )
 
     Stream

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/http/package.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/http/package.scala
@@ -1,5 +1,3 @@
 package com.permutive.pubsub
 
-package object http {
-
-}
+package object http {}

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleBatching.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleBatching.scala
@@ -15,11 +15,11 @@ import scala.util.Try
 
 object ExampleBatching extends IOApp {
 
-  final implicit val Codec: JsonValueCodec[ExampleObject] =
+  implicit final val Codec: JsonValueCodec[ExampleObject] =
     JsonCodecMaker.make[ExampleObject](CodecMakerConfig())
 
   implicit val encoder: MessageEncoder[ExampleObject] = (a: ExampleObject) => {
-    Try(writeToArray(a)).toEither
+    Try(writeToArray(a)).toEither,
   }
 
   case class ExampleObject(
@@ -28,10 +28,11 @@ object ExampleBatching extends IOApp {
   )
 
   override def run(args: List[String]): IO[ExitCode] = {
-    val client = Blocker[IO].flatMap(blocker =>
-      OkHttpBuilder
-        .withDefaultClient[IO](blocker.blockingContext)
-        .flatMap(_.resource)
+    val client = Blocker[IO].flatMap(
+      blocker =>
+        OkHttpBuilder
+          .withDefaultClient[IO](blocker.blockingContext)
+          .flatMap(_.resource),
     )
 
     implicit val unsafeLogger: Logger[IO] = Slf4jLogger.getLoggerFromName("fs2-google-pubsub")
@@ -49,17 +50,16 @@ object ExampleBatching extends IOApp {
       batchingConfig = BatchingHttpProducerConfig(
         batchSize = 10,
         maxLatency = 100.millis,
-
         retryTimes = 0,
         retryInitialDelay = 0.millis,
         retryNextDelay = _ + 250.millis,
       ),
-      _
+      _,
     )
 
     val messageCallback: Either[Throwable, Unit] => IO[Unit] = {
       case Right(_) => Logger[IO].info("Async message was sent successfully!")
-      case Left(e) => Logger[IO].warn(e)("Async message was sent unsuccessfully!")
+      case Left(e)  => Logger[IO].warn(e)("Async message was sent unsuccessfully!")
     }
 
     client
@@ -71,7 +71,7 @@ object ExampleBatching extends IOApp {
 
         val produceOneAsync = producer.produceAsync(
           record = ExampleObject("a84a3318-adbd-4eac-af78-eacf33be91ef", "example.com"),
-          callback = messageCallback
+          callback = messageCallback,
         )
 
         for {

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleBatching.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleBatching.scala
@@ -19,12 +19,12 @@ object ExampleBatching extends IOApp {
     JsonCodecMaker.make[ExampleObject](CodecMakerConfig())
 
   implicit val encoder: MessageEncoder[ExampleObject] = (a: ExampleObject) => {
-    Try(writeToArray(a)).toEither,
+    Try(writeToArray(a)).toEither
   }
 
   case class ExampleObject(
     projectId: String,
-    url: String,
+    url: String
   )
 
   override def run(args: List[String]): IO[ExitCode] = {
@@ -32,7 +32,7 @@ object ExampleBatching extends IOApp {
       blocker =>
         OkHttpBuilder
           .withDefaultClient[IO](blocker.blockingContext)
-          .flatMap(_.resource),
+          .flatMap(_.resource)
     )
 
     implicit val unsafeLogger: Logger[IO] = Slf4jLogger.getLoggerFromName("fs2-google-pubsub")
@@ -45,16 +45,16 @@ object ExampleBatching extends IOApp {
         host = "localhost",
         port = 8085,
         oauthTokenRefreshInterval = 30.minutes,
-        isEmulator = true,
+        isEmulator = true
       ),
       batchingConfig = BatchingHttpProducerConfig(
         batchSize = 10,
         maxLatency = 100.millis,
         retryTimes = 0,
         retryInitialDelay = 0.millis,
-        retryNextDelay = _ + 250.millis,
+        retryNextDelay = _ + 250.millis
       ),
-      _,
+      _
     )
 
     val messageCallback: Either[Throwable, Unit] => IO[Unit] = {
@@ -66,12 +66,12 @@ object ExampleBatching extends IOApp {
       .flatMap(mkProducer)
       .use { producer =>
         val produceOne = producer.produce(
-          record = ExampleObject("1f9774be-9d7c-4dd9-8d97-855b681938a9", "example.com"),
+          record = ExampleObject("1f9774be-9d7c-4dd9-8d97-855b681938a9", "example.com")
         )
 
         val produceOneAsync = producer.produceAsync(
           record = ExampleObject("a84a3318-adbd-4eac-af78-eacf33be91ef", "example.com"),
-          callback = messageCallback,
+          callback = messageCallback
         )
 
         for {

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleEmulator.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleEmulator.scala
@@ -15,11 +15,11 @@ import scala.util.Try
 
 object ExampleEmulator extends IOApp {
 
-  final implicit val Codec: JsonValueCodec[ExampleObject] =
+  implicit final val Codec: JsonValueCodec[ExampleObject] =
     JsonCodecMaker.make[ExampleObject](CodecMakerConfig())
 
   implicit val encoder: MessageEncoder[ExampleObject] = (a: ExampleObject) => {
-    Try(writeToArray(a)).toEither
+    Try(writeToArray(a)).toEither,
   }
 
   case class ExampleObject(
@@ -28,10 +28,11 @@ object ExampleEmulator extends IOApp {
   )
 
   override def run(args: List[String]): IO[ExitCode] = {
-    val client = Blocker[IO].flatMap(blocker =>
-      OkHttpBuilder
-        .withDefaultClient[IO](blocker.blockingContext)
-        .flatMap(_.resource)
+    val client = Blocker[IO].flatMap(
+      blocker =>
+        OkHttpBuilder
+          .withDefaultClient[IO](blocker.blockingContext)
+          .flatMap(_.resource),
     )
 
     implicit val unsafeLogger: Logger[IO] = Slf4jLogger.getLoggerFromName("fs2-google-pubsub")
@@ -46,14 +47,14 @@ object ExampleEmulator extends IOApp {
         oauthTokenRefreshInterval = 30.minutes,
         isEmulator = true,
       ),
-      _
+      _,
     )
 
     client
       .flatMap(mkProducer)
       .use { producer =>
         producer.produce(
-          record = ExampleObject("hsaudhiasuhdiu21hi3und", "example.com")
+          record = ExampleObject("hsaudhiasuhdiu21hi3und", "example.com"),
         )
       }
       .flatTap(output => IO(println(output)))

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleEmulator.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleEmulator.scala
@@ -19,12 +19,12 @@ object ExampleEmulator extends IOApp {
     JsonCodecMaker.make[ExampleObject](CodecMakerConfig())
 
   implicit val encoder: MessageEncoder[ExampleObject] = (a: ExampleObject) => {
-    Try(writeToArray(a)).toEither,
+    Try(writeToArray(a)).toEither
   }
 
   case class ExampleObject(
     projectId: String,
-    url: String,
+    url: String
   )
 
   override def run(args: List[String]): IO[ExitCode] = {
@@ -32,7 +32,7 @@ object ExampleEmulator extends IOApp {
       blocker =>
         OkHttpBuilder
           .withDefaultClient[IO](blocker.blockingContext)
-          .flatMap(_.resource),
+          .flatMap(_.resource)
     )
 
     implicit val unsafeLogger: Logger[IO] = Slf4jLogger.getLoggerFromName("fs2-google-pubsub")
@@ -45,16 +45,16 @@ object ExampleEmulator extends IOApp {
         host = "localhost",
         port = 8085,
         oauthTokenRefreshInterval = 30.minutes,
-        isEmulator = true,
+        isEmulator = true
       ),
-      _,
+      _
     )
 
     client
       .flatMap(mkProducer)
       .use { producer =>
         producer.produce(
-          record = ExampleObject("hsaudhiasuhdiu21hi3und", "example.com"),
+          record = ExampleObject("hsaudhiasuhdiu21hi3und", "example.com")
         )
       }
       .flatTap(output => IO(println(output)))

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleGoogle.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleGoogle.scala
@@ -15,11 +15,11 @@ import scala.util.Try
 
 object ExampleGoogle extends IOApp {
 
-  final implicit val Codec: JsonValueCodec[ExampleObject] =
+  implicit final val Codec: JsonValueCodec[ExampleObject] =
     JsonCodecMaker.make[ExampleObject](CodecMakerConfig())
 
   implicit val encoder: MessageEncoder[ExampleObject] = (a: ExampleObject) => {
-    Try(writeToArray(a)).toEither
+    Try(writeToArray(a)).toEither,
   }
 
   case class ExampleObject(
@@ -28,10 +28,11 @@ object ExampleGoogle extends IOApp {
   )
 
   override def run(args: List[String]): IO[ExitCode] = {
-    val client = Blocker[IO].flatMap(blocker =>
-      OkHttpBuilder
-        .withDefaultClient[IO](blocker.blockingContext)
-        .flatMap(_.resource)
+    val client = Blocker[IO].flatMap(
+      blocker =>
+        OkHttpBuilder
+          .withDefaultClient[IO](blocker.blockingContext)
+          .flatMap(_.resource),
     )
 
     implicit val unsafeLogger: Logger[IO] = Slf4jLogger.getLoggerFromName("fs2-google-pubsub")
@@ -45,14 +46,14 @@ object ExampleGoogle extends IOApp {
         port = 443,
         oauthTokenRefreshInterval = 30.minutes,
       ),
-      _
+      _,
     )
 
     client
       .flatMap(mkProducer)
       .use { producer =>
         producer.produce(
-          record = ExampleObject("70251cf8-5ffb-4c3f-8f2f-40b9bfe4147c", "example.com")
+          record = ExampleObject("70251cf8-5ffb-4c3f-8f2f-40b9bfe4147c", "example.com"),
         )
       }
       .flatTap(output => IO(println(output)))

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleGoogle.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleGoogle.scala
@@ -19,12 +19,12 @@ object ExampleGoogle extends IOApp {
     JsonCodecMaker.make[ExampleObject](CodecMakerConfig())
 
   implicit val encoder: MessageEncoder[ExampleObject] = (a: ExampleObject) => {
-    Try(writeToArray(a)).toEither,
+    Try(writeToArray(a)).toEither
   }
 
   case class ExampleObject(
     projectId: String,
-    url: String,
+    url: String
   )
 
   override def run(args: List[String]): IO[ExitCode] = {
@@ -32,7 +32,7 @@ object ExampleGoogle extends IOApp {
       blocker =>
         OkHttpBuilder
           .withDefaultClient[IO](blocker.blockingContext)
-          .flatMap(_.resource),
+          .flatMap(_.resource)
     )
 
     implicit val unsafeLogger: Logger[IO] = Slf4jLogger.getLoggerFromName("fs2-google-pubsub")
@@ -44,16 +44,16 @@ object ExampleGoogle extends IOApp {
       config = PubsubHttpProducerConfig(
         host = "pubsub.googleapis.com",
         port = 443,
-        oauthTokenRefreshInterval = 30.minutes,
+        oauthTokenRefreshInterval = 30.minutes
       ),
-      _,
+      _
     )
 
     client
       .flatMap(mkProducer)
       .use { producer =>
         producer.produce(
-          record = ExampleObject("70251cf8-5ffb-4c3f-8f2f-40b9bfe4147c", "example.com"),
+          record = ExampleObject("70251cf8-5ffb-4c3f-8f2f-40b9bfe4147c", "example.com")
         )
       }
       .flatTap(output => IO(println(output)))

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/JavaExecutor.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/JavaExecutor.scala
@@ -6,9 +6,9 @@ import cats.effect.{Resource, Sync}
 
 private[pubsub] object JavaExecutor {
   final def fixedThreadPool[F[_]](
-    size: Int,
+    size: Int
   )(
-    implicit F: Sync[F],
+    implicit F: Sync[F]
   ): Resource[F, ExecutorService] =
     Resource.make(F.delay(Executors.newFixedThreadPool(size)))(ex => F.delay(ex.shutdown()))
 }

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/JavaExecutor.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/JavaExecutor.scala
@@ -9,7 +9,6 @@ private[pubsub] object JavaExecutor {
     size: Int,
   )(
     implicit F: Sync[F],
-  ): Resource[F, ExecutorService] = {
+  ): Resource[F, ExecutorService] =
     Resource.make(F.delay(Executors.newFixedThreadPool(size)))(ex => F.delay(ex.shutdown()))
-  }
 }

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/ThreadPool.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/ThreadPool.scala
@@ -5,11 +5,10 @@ import cats.effect.{Resource, Sync}
 import scala.concurrent.ExecutionContext
 
 private[pubsub] object ThreadPool {
-  final def blockingThreadPool[F[_] : Sync](
-    parallelism: Int
-  ): Resource[F, ExecutionContext] = {
+  final def blockingThreadPool[F[_]: Sync](
+    parallelism: Int,
+  ): Resource[F, ExecutionContext] =
     JavaExecutor
       .fixedThreadPool(parallelism)
       .map(ExecutionContext.fromExecutor)
-  }
 }

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/ThreadPool.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/ThreadPool.scala
@@ -6,7 +6,7 @@ import scala.concurrent.ExecutionContext
 
 private[pubsub] object ThreadPool {
   final def blockingThreadPool[F[_]: Sync](
-    parallelism: Int,
+    parallelism: Int
   ): Resource[F, ExecutionContext] =
     JavaExecutor
       .fixedThreadPool(parallelism)

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/consumer/Model.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/consumer/Model.scala
@@ -16,6 +16,6 @@ object Model {
 
   case class Record[F[_], A](value: A, ack: F[Unit], nack: F[Unit])
   object Record {
-    implicit def show[F[_], A : Show]: Show[Record[F, A]] = (record: Record[F, A]) => s"Record(${record.value.show})"
+    implicit def show[F[_], A: Show]: Show[Record[F, A]] = (record: Record[F, A]) => s"Record(${record.value.show})"
   }
 }

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/AsyncPubsubProducer.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/AsyncPubsubProducer.scala
@@ -12,7 +12,7 @@ trait AsyncPubsubProducer[F[_], A] {
     uniqueId: String = UUID.randomUUID().toString,
   ): F[Unit]
 
-  def produceManyAsync[G[_] : Foldable](
+  def produceManyAsync[G[_]: Foldable](
     records: G[Model.AsyncRecord[F, A]],
   ): F[Unit]
 
@@ -22,7 +22,7 @@ trait AsyncPubsubProducer[F[_], A] {
     uniqueId: String = UUID.randomUUID().toString,
   ): F[F[Unit]]
 
-  def produceMany[G[_] : Traverse](
+  def produceMany[G[_]: Traverse](
     records: G[Model.SimpleRecord[A]],
   ): F[G[F[Unit]]]
 }

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/AsyncPubsubProducer.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/AsyncPubsubProducer.scala
@@ -9,20 +9,20 @@ trait AsyncPubsubProducer[F[_], A] {
     record: A,
     callback: Either[Throwable, Unit] => F[Unit],
     metadata: Map[String, String] = Map.empty,
-    uniqueId: String = UUID.randomUUID().toString,
+    uniqueId: String = UUID.randomUUID().toString
   ): F[Unit]
 
   def produceManyAsync[G[_]: Foldable](
-    records: G[Model.AsyncRecord[F, A]],
+    records: G[Model.AsyncRecord[F, A]]
   ): F[Unit]
 
   def produce(
     record: A,
     metadata: Map[String, String] = Map.empty,
-    uniqueId: String = UUID.randomUUID().toString,
+    uniqueId: String = UUID.randomUUID().toString
   ): F[F[Unit]]
 
   def produceMany[G[_]: Traverse](
-    records: G[Model.SimpleRecord[A]],
+    records: G[Model.SimpleRecord[A]]
   ): F[G[F[Unit]]]
 }

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/Model.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/Model.scala
@@ -16,13 +16,13 @@ object Model {
   final case class SimpleRecord[A](
     value: A,
     metadata: Map[String, String] = Map.empty,
-    uniqueId: String = UUID.randomUUID().toString,
+    uniqueId: String = UUID.randomUUID().toString
   ) extends Record[A]
 
   final case class AsyncRecord[F[_], A](
     value: A,
     callback: Either[Throwable, Unit] => F[Unit],
     metadata: Map[String, String] = Map.empty,
-    uniqueId: String = UUID.randomUUID().toString,
+    uniqueId: String = UUID.randomUUID().toString
   ) extends Record[A]
 }

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/Model.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/Model.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 object Model {
   case class MessageId(value: String) extends AnyVal
   case class ProjectId(value: String) extends AnyVal
-  case class Topic(value: String) extends AnyVal
+  case class Topic(value: String)     extends AnyVal
 
   trait Record[A] {
     def value: A
@@ -16,7 +16,7 @@ object Model {
   final case class SimpleRecord[A](
     value: A,
     metadata: Map[String, String] = Map.empty,
-    uniqueId: String = UUID.randomUUID().toString
+    uniqueId: String = UUID.randomUUID().toString,
   ) extends Record[A]
 
   final case class AsyncRecord[F[_], A](

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/PubsubProducer.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/PubsubProducer.scala
@@ -9,7 +9,7 @@ trait PubsubProducer[F[_], A] {
   def produce(
     record: A,
     metadata: Map[String, String] = Map.empty,
-    uniqueId: String = UUID.randomUUID().toString,
+    uniqueId: String = UUID.randomUUID().toString
   ): F[MessageId]
 
   def produceMany[G[_]: Traverse](records: G[Model.Record[A]]): F[List[MessageId]]

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/PubsubProducer.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/PubsubProducer.scala
@@ -12,5 +12,5 @@ trait PubsubProducer[F[_], A] {
     uniqueId: String = UUID.randomUUID().toString,
   ): F[MessageId]
 
-  def produceMany[G[_] : Traverse](records: G[Model.Record[A]]): F[List[MessageId]]
+  def produceMany[G[_]: Traverse](records: G[Model.Record[A]]): F[List[MessageId]]
 }


### PR DESCRIPTION
Includes the commits from #15 but rebased and with Scalafmt updated and re-run.

I agree with @bastewart's assessment in #15 that `trailingCommas = always` does weird stuff. Until Scalafmt supports trailing commas for varargs calls only, I think we should default to `trailingCommas = preserve`. I've reinstated that here by switching to `trailingCommas = never` to undo the run with `always`, formatting, and then setting `trailingCommas = preserve`.