### PR TITLE
Update Cats and other dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 jdk: openjdk11
 
 scala:
-  - 2.12.8
+  - 2.12.10
 
 branches:
   only:

--- a/build.sc
+++ b/build.sc
@@ -7,20 +7,20 @@ object Dependencies {
 
   object version {
     val scala212 = "2.12.10"
-    val scala213 = "2.13.0"
+    val scala213 = "2.13.1"
 
     val cross    = List(scala212)
 
     val catsCore = "2.0.0"
     val effect   = "2.0.0"
-    val fs2      = "1.0.5"
-    val http4s   = "0.20.10"
+    val fs2      = "2.0.1"
+    val http4s   = "0.21.0-M5"
     val log4cats = "1.0.0"
     val jwt      = "3.8.2"
     val jsoniter = "0.55.2"
     val gcp      = "1.87.0"
 
-    val scalatest = "3.1.0-RC1"
+    val scalatest = "3.1.0-RC3"
     val scalatestPlus = "3.1.0.0-RC2"
   }
 

--- a/build.sc
+++ b/build.sc
@@ -6,22 +6,22 @@ import mill.scalalib.scalafmt._
 object Dependencies {
 
   object version {
-    val scala212 = "2.12.9"
+    val scala212 = "2.12.10"
     val scala213 = "2.13.0"
 
     val cross    = List(scala212)
 
-    val catsCore = "1.6.1"
-    val effect   = "1.4.0"
+    val catsCore = "2.0.0"
+    val effect   = "2.0.0"
     val fs2      = "1.0.5"
     val http4s   = "0.20.10"
-    val log4cats = "0.3.0"
+    val log4cats = "1.0.0"
     val jwt      = "3.8.2"
-    val jsoniter = "0.55.0"
+    val jsoniter = "0.55.2"
     val gcp      = "1.87.0"
 
-    val scalatest = "3.1.0-SNAP13"
-    val scalatestPlus = "1.0.0-SNAP8"
+    val scalatest = "3.1.0-RC1"
+    val scalatestPlus = "3.1.0.0-RC2"
   }
 
   object libraries {

--- a/build.sc
+++ b/build.sc
@@ -9,7 +9,7 @@ object Dependencies {
     val scala212 = "2.12.10"
     val scala213 = "2.13.1"
 
-    val cross    = List(scala212)
+    val cross    = List(scala212, scala213)
 
     val catsCore = "2.0.0"
     val effect   = "2.0.0"

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/consumer/http/Example.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/consumer/http/Example.scala
@@ -22,7 +22,7 @@ object Example extends IOApp {
     val client = Blocker[IO].flatMap(
       blocker =>
         OkHttpBuilder
-          .withDefaultClient[IO](blocker.blockingContext)
+          .withDefaultClient[IO](blocker)
           .flatMap(_.resource)
     )
 

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleBatching.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleBatching.scala
@@ -31,7 +31,7 @@ object ExampleBatching extends IOApp {
     val client = Blocker[IO].flatMap(
       blocker =>
         OkHttpBuilder
-          .withDefaultClient[IO](blocker.blockingContext)
+          .withDefaultClient[IO](blocker)
           .flatMap(_.resource)
     )
 

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleEmulator.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleEmulator.scala
@@ -31,7 +31,7 @@ object ExampleEmulator extends IOApp {
     val client = Blocker[IO].flatMap(
       blocker =>
         OkHttpBuilder
-          .withDefaultClient[IO](blocker.blockingContext)
+          .withDefaultClient[IO](blocker)
           .flatMap(_.resource)
     )
 

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleGoogle.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleGoogle.scala
@@ -31,7 +31,7 @@ object ExampleGoogle extends IOApp {
     val client = Blocker[IO].flatMap(
       blocker =>
         OkHttpBuilder
-          .withDefaultClient[IO](blocker.blockingContext)
+          .withDefaultClient[IO](blocker)
           .flatMap(_.resource)
     )
 


### PR DESCRIPTION
There's a new http4s 0.12 milestone now, so we could do a milestone release with this PR.

~~This doesn't help us much since we can't update fs2 or reintroduce 2.13 until http4s 0.21.0 is out, but these updates are safe.~~