### PR TITLE
Avoid new default in Scalafmt 2.2.2

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -6,5 +6,6 @@ maxColumn = 120
 trailingCommas = preserve
 danglingParentheses = true
 assumeStandardLibraryStripMargin = true
+newlines.avoidEmptyLinesAroundBlock = false
 
 rewrite.rules = [RedundantBraces, RedundantParens, SortImports, SortModifiers]


### PR DESCRIPTION
I've confirmed that running Scalafmt doesn't do anything after this change:

```
mill mill.scalalib.scalafmt.ScalafmtModule/reformatAll __.sources
```