### PR TITLE
Back to Scalafmt 2.2.1

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 2.2.2
+version = 2.2.1
 
 align = more
 continuationIndent.defnSite = 2


### PR DESCRIPTION
See #28 for explanation. I don't really like the `edition` approach, personally, so I'm just rolling back to 2.2.1 in the hope that the Scalafmt maintainers will decide either to make this configurable soon or to change back the default.