### PR TITLE
Improve HTTP error logs when PubSub returns an invalid response

### DIFF
--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
@@ -2,7 +2,7 @@ package com.permutive.pubsub.consumer.grpc.internal
 
 import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue, TimeUnit}
 
-import cats.effect.{Blocker, Concurrent, ContextShift, Resource, Sync}
+import cats.effect.{Blocker, ContextShift, Resource, Sync}
 import cats.syntax.all._
 import com.google.api.gax.batching.FlowControlSettings
 import com.google.cloud.pubsub.v1.{AckReplyConsumer, MessageReceiver, Subscriber}

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/HttpPubsubReader.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/HttpPubsubReader.scala
@@ -116,9 +116,7 @@ private[internal] class HttpPubsubReader[F[_]: Logger] private (
       .as[Array[Byte]]
       .map(arr =>
         Try(readFromArray[PubSubErrorResponse](arr))
-          .map(PubSubError.fromResponse)
-          .toOption
-          .getOrElse(PubSubError.UnparseableBody(new String(arr)))
+          .fold(_ => PubSubError.UnparseableBody(new String(arr)), PubSubError.fromResponse)
       )
 }
 

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/HttpPubsubReader.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/HttpPubsubReader.scala
@@ -26,9 +26,10 @@ import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.headers._
 
 import scala.concurrent.duration._
+import scala.util.Try
 import scala.util.control.NoStackTrace
 
-private[internal] class HttpPubsubReader[F[_]] private (
+private[internal] class HttpPubsubReader[F[_]: Logger] private (
   baseApiUrl: Uri,
   client: Client[F],
   tokenF: F[AccessToken],
@@ -41,9 +42,6 @@ private[internal] class HttpPubsubReader[F[_]] private (
 
   import HttpPubsubReader._
   import dsl._
-
-  implicit final val ErrorEntityDecoder: EntityDecoder[F, PubSubErrorResponse] =
-    EntityDecoder.byteArrayDecoder.map(readFromArray[PubSubErrorResponse](_))
 
   final private[this] val pullEndpoint           = baseApiUrl.copy(path = baseApiUrl.path.concat(":pull"))
   final private[this] val acknowledgeEndpoint    = baseApiUrl.copy(path = baseApiUrl.path.concat(":acknowledge"))
@@ -66,7 +64,9 @@ private[internal] class HttpPubsubReader[F[_]] private (
         `Content-Type`(MediaType.application.json)
       )
       resp <- client.expectOr[Array[Byte]](req)(onError)
-      resp <- F.delay(readFromArray[PullResponse](resp))
+      resp <- F.delay(readFromArray[PullResponse](resp)).onError {
+        case _ => Logger[F].error(s"Pull response from PubSub was invalid. Body: ${new String(resp)}")
+      }
     } yield resp
   }
 
@@ -112,7 +112,14 @@ private[internal] class HttpPubsubReader[F[_]] private (
 
   @inline
   final private def onError(resp: Response[F]): F[Throwable] =
-    resp.as[PubSubErrorResponse].map(PubSubError.fromResponse)
+    resp
+      .as[Array[Byte]]
+      .map(arr =>
+        Try(readFromArray[PubSubErrorResponse](arr))
+          .map(PubSubError.fromResponse)
+          .toOption
+          .getOrElse(PubSubError.UnparseableBody(new String(arr)))
+      )
 }
 
 private[internal] object HttpPubsubReader {
@@ -154,12 +161,13 @@ private[internal] object HttpPubsubReader {
     )
 
   sealed abstract class PubSubError(msg: String)
-      extends Throwable(s"Failed request to PubSub. Underlying message: ${msg}")
+      extends Throwable(s"Failed request to PubSub. Underlying message: $msg")
       with NoStackTrace
 
   object PubSubError {
     case object NoAckIds                          extends PubSubError("No ack ids specified")
     case class Unknown(body: PubSubErrorResponse) extends PubSubError(body.toString)
+    case class UnparseableBody(body: String)      extends PubSubError(s"Body could not be parsed to error response: $body")
 
     def fromResponse(response: PubSubErrorResponse): PubSubError =
       response.error.message match {

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/PubsubSubscriber.scala
@@ -28,7 +28,9 @@ private[http] object PubsubSubscriber {
       case PubSubError.NoAckIds =>
         Logger[F].warn(s"[PubSub/Ack] a message was sent with no ids in it. This is likely a bug.")
       case PubSubError.Unknown(e) =>
-        Logger[F].error(s"[PubSub] Unknown PubSub error occurred. Body is: ${e}")
+        Logger[F].error(s"[PubSub] Unknown PubSub error occurred. Body is: $e")
+      case PubSubError.UnparseableBody(body) =>
+        Logger[F].error(s"[PubSub] A response from PubSub could not be parsed. Body is: $body")
       case e =>
         Logger[F].error(e)(s"[PubSub] An unknown error occurred")
     }

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/internal/DefaultHttpPublisher.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/internal/DefaultHttpPublisher.scala
@@ -27,7 +27,6 @@ import scala.util.control.NoStackTrace
 
 private[http] class DefaultHttpPublisher[F[_], A: MessageEncoder] private (
   baseApiUrl: Uri,
-  topic: Model.Topic,
   client: Client[F],
   tokenF: F[AccessToken],
 )(
@@ -107,7 +106,6 @@ private[http] object DefaultHttpPublisher {
       )
     } yield new DefaultHttpPublisher[F, A](
       baseApiUrl = createBaseApiUri(projectId, topic, config),
-      topic = topic,
       client = httpClient,
       tokenF = accessTokenRefEffect.value
     )


### PR DESCRIPTION
The complete message body is now logged rather than just the
jsoniter-scala decoding error which only includes the first few
characters of the body.

Also fixes an unhandled error that was thrown in an EntityDecoder.