### PR TITLE
consumer retries all (retriable) requests to pubsub

### DIFF
--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/PubsubSubscriber.scala
@@ -14,6 +14,7 @@ import org.http4s.client.middleware.{Retry, RetryPolicy}
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration._
+import RetryPolicy.exponentialBackoff
 
 private[http] object PubsubSubscriber {
 
@@ -83,12 +84,5 @@ private[http] object PubsubSubscriber {
   }
 
   private def httpClientDefaultRetryPolicy[F[_]]: RetryPolicy[F] =
-    RetryPolicy(
-      backoff = { retries =>
-        if (retries <= 3)
-          Some(retries.seconds)
-        else
-          None
-      }
-    )
+    RetryPolicy(exponentialBackoff(maxWait = 5.seconds, maxRetry = 3))
 }

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/consumer/http/Example.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/consumer/http/Example.scala
@@ -7,6 +7,7 @@ import com.permutive.pubsub.consumer.decoder.MessageDecoder
 import fs2.Stream
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.http4s.client.Client
 import org.http4s.client.okhttp.OkHttpBuilder
 
 import scala.util.Try
@@ -27,18 +28,19 @@ object Example extends IOApp {
 
     implicit val unsafeLogger: Logger[IO] = Slf4jLogger.getLoggerFromName("fs2-google-pubsub")
 
-    val mkConsumer = PubsubHttpConsumer.subscribe[IO, ValueHolder](
-      Model.ProjectId("test-project"),
-      Model.Subscription("example-sub"),
-      "/path/to/service/account",
-      PubsubHttpConsumerConfig(
-        host = "localhost",
-        port = 8085,
-        isEmulator = true
-      ),
-      _,
-      (msg, err, ack, _) => IO(println(s"Msg $msg got error $err")) >> ack
-    )
+    def mkConsumer(client: Client[IO]) =
+      PubsubHttpConsumer.subscribe[IO, ValueHolder](
+        Model.ProjectId("test-project"),
+        Model.Subscription("example-sub"),
+        "/path/to/service/account",
+        PubsubHttpConsumerConfig(
+          host = "localhost",
+          port = 8085,
+          isEmulator = true
+        ),
+        client,
+        (msg, err, ack, _) => IO(println(s"Msg $msg got error $err")) >> ack,
+      )
 
     Stream
       .resource(client)


### PR DESCRIPTION
It looks like GCP PubSub can be flaky and sometimes returns 502 errors.

This issue has already been spotted in libraries [like this one](https://github.com/googleapis/nodejs-storage/issues/1233), and the solution was [to add retries](https://github.com/googleapis/nodejs-storage/releases/tag/v5.7.3).

My proposal is to add the http4s `Retry` middleware to the `httpClient` that gets passed in the `PubsubSubscriber`.

All of the http endpoints the client hits do not conform to REST idepotency and retriability standards, therefore we need to set retries also on POST requests.

Even if the endpoints called by the client are POST they are actually idempotent, so it's safe to use retries on them.