### PR TITLE
Obtain  auth token from metadata

### DIFF
--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubHttpConsumer.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubHttpConsumer.scala
@@ -28,7 +28,7 @@ object PubsubHttpConsumer {
   final def subscribe[F[_]: Concurrent: Timer: Logger, A: MessageDecoder](
     projectId: ProjectId,
     subscription: Subscription,
-    serviceAccountPath: String,
+    serviceAccountPath: Option[String],
     config: PubsubHttpConsumerConfig[F],
     httpClient: Client[F],
     errorHandler: (PubsubMessage, Throwable, F[Unit], F[Unit]) => F[Unit],
@@ -54,7 +54,7 @@ object PubsubHttpConsumer {
   final def subscribeAndAck[F[_]: Concurrent: Timer: Logger, A: MessageDecoder](
     projectId: ProjectId,
     subscription: Subscription,
-    serviceAccountPath: String,
+    serviceAccountPath: Option[String],
     config: PubsubHttpConsumerConfig[F],
     httpClient: Client[F],
     errorHandler: (PubsubMessage, Throwable, F[Unit], F[Unit]) => F[Unit],
@@ -75,7 +75,7 @@ object PubsubHttpConsumer {
   final def subscribeRaw[F[_]: Concurrent: Timer: Logger](
     projectId: ProjectId,
     subscription: Subscription,
-    serviceAccountPath: String,
+    serviceAccountPath: Option[String],
     config: PubsubHttpConsumerConfig[F],
     httpClient: Client[F],
     httpClientRetryPolicy: RetryPolicy[F] = recklesslyRetryPolicy[F],

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/PubsubSubscriber.scala
@@ -19,7 +19,7 @@ private[http] object PubsubSubscriber {
   def subscribe[F[_]: Timer: Logger](
     projectId: ProjectId,
     subscription: Subscription,
-    serviceAccountPath: String,
+    serviceAccountPath: Option[String],
     config: PubsubHttpConsumerConfig[F],
     httpClient: Client[F],
     httpClientRetryPolicy: RetryPolicy[F]

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/InstanceMetadataOAuth.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/InstanceMetadataOAuth.scala
@@ -1,0 +1,50 @@
+package com.permutive.pubsub.http.oauth
+
+import java.time.Instant
+
+import cats.Applicative
+import cats.syntax.functor._
+import cats.syntax.flatMap._
+import cats.syntax.option._
+import cats.syntax.applicativeError._
+import cats.effect.Sync
+import com.github.plokhotnyuk.jsoniter_scala.core.readFromArray
+import com.permutive.pubsub.http.oauth.GoogleOAuth.FailedRequest
+import io.chrisdavenport.log4cats.Logger
+import org.http4s.Method.GET
+import org.http4s.client.Client
+import org.http4s.client.dsl.Http4sClientDsl
+import org.http4s.{Header, Uri}
+
+import scala.concurrent.duration._
+import scala.util.control.NoStackTrace
+
+// Obtains OAuth token from instance metadata
+// https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances#applications
+class InstanceMetadataOAuth[F[_]: Sync: Logger](httpClient: Client[F]) extends OAuth[F] with Http4sClientDsl[F] {
+
+  // https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances#applications
+  final private[this] val googleInstanceMetadataTokenUri = Uri.unsafeFromString(
+    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
+  )
+
+  final private[this] val request = GET(googleInstanceMetadataTokenUri, Header("Metadata-Flavor", "Google"))
+
+  override def authenticate(iss: String, scope: String, exp: Instant, iat: Instant): F[Option[AccessToken]] =
+    httpClient
+      .expectOr[Array[Byte]](request) { resp =>
+        resp.as[String].map(FailedRequest.apply)
+      }
+      .flatMap(bytes => Sync[F].delay(readFromArray[AccessToken](bytes)).map(_.some))
+      .handleErrorWith { e =>
+        Logger[F].warn(e)("Failed to retrieve JWT Access Token from Google") >> Applicative[F].pure(None)
+      }
+
+  final override val maxDuration: FiniteDuration = 1.hour
+}
+
+object InstanceMetadataOAuth {
+  case class FailedRequest(body: String)
+      extends RuntimeException(s"Failed request, got response: $body")
+      with NoStackTrace
+}

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/BatchingHttpPubsubProducer.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/BatchingHttpPubsubProducer.scala
@@ -11,7 +11,7 @@ object BatchingHttpPubsubProducer {
   def resource[F[_]: Concurrent: Timer: Logger, A: MessageEncoder](
     projectId: Model.ProjectId,
     topic: Model.Topic,
-    googleServiceAccountPath: String,
+    googleServiceAccountPath: Option[String],
     config: PubsubHttpProducerConfig[F],
     batchingConfig: BatchingHttpProducerConfig,
     httpClient: Client[F]

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/HttpPubsubProducer.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/HttpPubsubProducer.scala
@@ -11,7 +11,7 @@ object HttpPubsubProducer {
   def resource[F[_]: Concurrent: Timer: Logger, A: MessageEncoder](
     projectId: Model.ProjectId,
     topic: Model.Topic,
-    googleServiceAccountPath: String,
+    googleServiceAccountPath: Option[String],
     config: PubsubHttpProducerConfig[F],
     httpClient: Client[F]
   ): Resource[F, PubsubProducer[F, A]] =

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/internal/DefaultHttpPublisher.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/internal/DefaultHttpPublisher.scala
@@ -91,27 +91,28 @@ private[http] object DefaultHttpPublisher {
     httpClient: Client[F]
   ): Resource[F, PubsubProducer[F, A]] =
     for {
-      tokenProvider <- Resource.liftF(
-        if (config.isEmulator) DefaultTokenProvider.noAuth.pure
+      accessToken <-
+        if (config.isEmulator) Resource.pure(DefaultTokenProvider.noAuth.accessToken)
         else
-          serviceAccountPath.fold(DefaultTokenProvider.instanceMetadata(httpClient).pure)(
-            DefaultTokenProvider.google(_, httpClient)
+          serviceAccountPath.fold(Resource.pure(DefaultTokenProvider.instanceMetadata(httpClient).accessToken))(path =>
+            for {
+              tokenProvider <- Resource.liftF(DefaultTokenProvider.google(path, httpClient))
+              accessTokenRefEffect <- RefreshableEffect.createRetryResource(
+                refresh = tokenProvider.accessToken,
+                refreshInterval = config.oauthTokenRefreshInterval,
+                onRefreshSuccess = config.onTokenRefreshSuccess.getOrElse(Applicative[F].unit),
+                onRefreshError = config.onTokenRefreshError,
+                retryDelay = config.oauthTokenFailureRetryDelay,
+                retryNextDelay = config.oauthTokenFailureRetryNextDelay,
+                retryMaxAttempts = config.oauthTokenFailureRetryMaxAttempts,
+                onRetriesExhausted = config.onTokenRetriesExhausted,
+              )
+            } yield accessTokenRefEffect.value
           )
-      )
-      accessTokenRefEffect <- RefreshableEffect.createRetryResource(
-        refresh = tokenProvider.accessToken,
-        refreshInterval = config.oauthTokenRefreshInterval,
-        onRefreshSuccess = config.onTokenRefreshSuccess.getOrElse(Applicative[F].unit),
-        onRefreshError = config.onTokenRefreshError,
-        retryDelay = config.oauthTokenFailureRetryDelay,
-        retryNextDelay = config.oauthTokenFailureRetryNextDelay,
-        retryMaxAttempts = config.oauthTokenFailureRetryMaxAttempts,
-        onRetriesExhausted = config.onTokenRetriesExhausted,
-      )
     } yield new DefaultHttpPublisher[F, A](
       baseApiUrl = createBaseApiUri(projectId, topic, config),
       client = httpClient,
-      tokenF = accessTokenRefEffect.value
+      tokenF = accessToken
     )
 
   def createBaseApiUri[F[_]](

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/PubSubSpec.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/PubSubSpec.scala
@@ -124,7 +124,7 @@ trait PubSubSpec extends AnyFlatSpec with ForAllTestContainer with Matchers with
     HttpPubsubProducer.resource[IO, ValueHolder](
       com.permutive.pubsub.producer.Model.ProjectId(project),
       com.permutive.pubsub.producer.Model.Topic(topic),
-      "/path/to/service/account",
+      Some("/path/to/service/account"),
       config = PubsubHttpProducerConfig(
         host = container.host,
         port = container.mappedPort(8085),
@@ -142,7 +142,7 @@ trait PubSubSpec extends AnyFlatSpec with ForAllTestContainer with Matchers with
       out <- PubsubHttpConsumer.subscribe[IO, ValueHolder](
         Model.ProjectId(project),
         Model.Subscription(subscription),
-        "/path/to/service/account",
+        Some("/path/to/service/account"),
         PubsubHttpConsumerConfig(
           host = container.host,
           port = container.mappedPort(8085),

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/consumer/http/Example.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/consumer/http/Example.scala
@@ -36,7 +36,7 @@ object Example extends IOApp {
       PubsubHttpConsumer.subscribe[IO, ValueHolder](
         Model.ProjectId("test-project"),
         Model.Subscription("example-sub"),
-        "/path/to/service/account",
+        Some("/path/to/service/account"),
         PubsubHttpConsumerConfig(
           host = "localhost",
           port = 8085,

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleBatching.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleBatching.scala
@@ -38,7 +38,7 @@ object ExampleBatching extends IOApp {
     val mkProducer = BatchingHttpPubsubProducer.resource[IO, ExampleObject](
       projectId = Model.ProjectId("test-project"),
       topic = Model.Topic("example-topic"),
-      googleServiceAccountPath = "/path/to/service/account",
+      googleServiceAccountPath = Some("/path/to/service/account"),
       config = PubsubHttpProducerConfig(
         host = "localhost",
         port = 8085,

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleEmulator.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleEmulator.scala
@@ -39,7 +39,7 @@ object ExampleEmulator extends IOApp {
     val mkProducer = HttpPubsubProducer.resource[IO, ExampleObject](
       projectId = Model.ProjectId("test-project"),
       topic = Model.Topic("example-topic"),
-      googleServiceAccountPath = "/path/to/nothing",
+      googleServiceAccountPath = Some("/path/to/nothing"),
       config = PubsubHttpProducerConfig(
         host = "localhost",
         port = 8085,

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleGoogle.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleGoogle.scala
@@ -39,7 +39,7 @@ object ExampleGoogle extends IOApp {
     val mkProducer = HttpPubsubProducer.resource[IO, ExampleObject](
       projectId = Model.ProjectId("test-project"),
       topic = Model.Topic("example-topic"),
-      googleServiceAccountPath = "/path/to/service/account",
+      googleServiceAccountPath = Some("/path/to/service/account"),
       config = PubsubHttpProducerConfig(
         host = "pubsub.googleapis.com",
         port = 443,


### PR DESCRIPTION
Use GCP instance metadata to retrieve an access token

Ported some of our internal code (that we should open source) for obtaining the token.

Discussed with @CremboC how best to do this without a large refactor, considering CE3 is pending, opted for making the service account path optional and breaking the API :/

Once we're happy with this, I'll cut another CE2 release and port the changes to CE3 in master.