### PR TITLE
Rename fields for consistency with GCP schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ object ExampleGoogle extends IOApp {
     val http = AsyncHttpClient.resource[IO]()
     http.flatMap(mkProducer).use { producer =>
       producer.produce(
-        record = ExampleObject("70251cf8-5ffb-4c3f-8f2f-40b9bfe4147c", "example.com")
+        data = ExampleObject("70251cf8-5ffb-4c3f-8f2f-40b9bfe4147c", "example.com")
       )
     }.flatTap(output => IO(println(output))) >> IO.pure(ExitCode.Success)
   }
@@ -296,11 +296,11 @@ object ExampleBatching extends IOApp {
       .flatMap(mkProducer)
       .use { producer =>
         val produceOne = producer.produce(
-          record = ExampleObject("1f9774be-9d7c-4dd9-8d97-855b681938a9", "example.com"),
+          data = ExampleObject("1f9774be-9d7c-4dd9-8d97-855b681938a9", "example.com"),
         )
 
         val produceOneAsync = producer.produceAsync(
-          record = ExampleObject("a84a3318-adbd-4eac-af78-eacf33be91ef", "example.com"),
+          data = ExampleObject("a84a3318-adbd-4eac-af78-eacf33be91ef", "example.com"),
           callback = messageCallback
         )
 

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/internal/DefaultHttpPublisher.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/internal/DefaultHttpPublisher.scala
@@ -35,8 +35,8 @@ private[http] class DefaultHttpPublisher[F[_]: Logger, A: MessageEncoder] privat
   final private[this] val publishRoute =
     Uri.unsafeFromString(s"${baseApiUrl.renderString}:publish")
 
-  final override def produce(record: A, metadata: Map[String, String], uniqueId: String): F[MessageId] =
-    produceMany[List](List(Model.SimpleRecord(record, metadata, uniqueId))).map(_.head)
+  final override def produce(data: A, attributes: Map[String, String], uniqueId: String): F[MessageId] =
+    produceMany[List](List(Model.SimpleRecord(data, attributes, uniqueId))).map(_.head)
 
   final override def produceMany[G[_]: Traverse](records: G[Model.Record[A]]): F[List[MessageId]] =
     for {
@@ -63,8 +63,8 @@ private[http] class DefaultHttpPublisher[F[_]: Logger, A: MessageEncoder] privat
   private def recordToMessage(record: Model.Record[A]): F[Message] =
     F.fromEither(
       MessageEncoder[A]
-        .encode(record.value)
-        .map(toMessage(_, record.uniqueId, record.metadata))
+        .encode(record.data)
+        .map(toMessage(_, record.uniqueId, record.attributes))
     )
 
   @inline

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleBatching.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleBatching.scala
@@ -62,11 +62,11 @@ object ExampleBatching extends IOApp {
       .flatMap(mkProducer)
       .use { producer =>
         val produceOne = producer.produce(
-          record = ExampleObject("1f9774be-9d7c-4dd9-8d97-855b681938a9", "example.com")
+          data = ExampleObject("1f9774be-9d7c-4dd9-8d97-855b681938a9", "example.com")
         )
 
         val produceOneAsync = producer.produceAsync(
-          record = ExampleObject("a84a3318-adbd-4eac-af78-eacf33be91ef", "example.com"),
+          data = ExampleObject("a84a3318-adbd-4eac-af78-eacf33be91ef", "example.com"),
           callback = messageCallback
         )
 

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleEmulator.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleEmulator.scala
@@ -51,7 +51,7 @@ object ExampleEmulator extends IOApp {
       .flatMap(mkProducer)
       .use { producer =>
         producer.produce(
-          record = ExampleObject("hsaudhiasuhdiu21hi3und", "example.com")
+          data = ExampleObject("hsaudhiasuhdiu21hi3und", "example.com")
         )
       }
       .flatTap(output => IO(println(output)))

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleGoogle.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleGoogle.scala
@@ -50,7 +50,7 @@ object ExampleGoogle extends IOApp {
       .flatMap(mkProducer)
       .use { producer =>
         producer.produce(
-          record = ExampleObject("70251cf8-5ffb-4c3f-8f2f-40b9bfe4147c", "example.com")
+          data = ExampleObject("70251cf8-5ffb-4c3f-8f2f-40b9bfe4147c", "example.com")
         )
       }
       .flatTap(output => IO(println(output)))

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/AsyncPubsubProducer.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/AsyncPubsubProducer.scala
@@ -6,9 +6,9 @@ import cats.{Foldable, Traverse}
 
 trait AsyncPubsubProducer[F[_], A] {
   def produceAsync(
-    record: A,
+    data: A,
     callback: Either[Throwable, Unit] => F[Unit],
-    metadata: Map[String, String] = Map.empty,
+    attributes: Map[String, String] = Map.empty,
     uniqueId: String = UUID.randomUUID().toString
   ): F[Unit]
 
@@ -17,8 +17,8 @@ trait AsyncPubsubProducer[F[_], A] {
   ): F[Unit]
 
   def produce(
-    record: A,
-    metadata: Map[String, String] = Map.empty,
+    data: A,
+    attributes: Map[String, String] = Map.empty,
     uniqueId: String = UUID.randomUUID().toString
   ): F[F[Unit]]
 

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/Model.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/Model.scala
@@ -8,21 +8,21 @@ object Model {
   case class Topic(value: String)     extends AnyVal
 
   trait Record[A] {
-    def value: A
-    def metadata: Map[String, String]
+    def data: A
+    def attributes: Map[String, String]
     def uniqueId: String
   }
 
   final case class SimpleRecord[A](
-    value: A,
-    metadata: Map[String, String] = Map.empty,
+    data: A,
+    attributes: Map[String, String] = Map.empty,
     uniqueId: String = UUID.randomUUID().toString
   ) extends Record[A]
 
   final case class AsyncRecord[F[_], A](
-    value: A,
+    data: A,
     callback: Either[Throwable, Unit] => F[Unit],
-    metadata: Map[String, String] = Map.empty,
+    attributes: Map[String, String] = Map.empty,
     uniqueId: String = UUID.randomUUID().toString
   ) extends Record[A]
 }

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/PubsubProducer.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/PubsubProducer.scala
@@ -7,8 +7,8 @@ import com.permutive.pubsub.producer.Model.MessageId
 
 trait PubsubProducer[F[_], A] {
   def produce(
-    record: A,
-    metadata: Map[String, String] = Map.empty,
+    data: A,
+    attributes: Map[String, String] = Map.empty,
     uniqueId: String = UUID.randomUUID().toString
   ): F[MessageId]
 


### PR DESCRIPTION
* `record` is now `data`
* `metadata` is now `attributes`

Example pub/sub doc with these field names: https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.PubsubMessage