### PR TITLE
Bump dependencies; Minor tweaks before release

### DIFF
--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumer.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumer.scala
@@ -9,6 +9,8 @@ import com.permutive.pubsub.consumer.grpc.internal.PubsubSubscriber
 import com.permutive.pubsub.consumer.{ConsumerRecord, Model}
 import fs2.Stream
 
+import scala.util.control.NoStackTrace
+
 object PubsubGoogleConsumer {
 
   /**
@@ -16,7 +18,9 @@ object PubsubGoogleConsumer {
     *
     * @param cause the cause of the failure
     */
-  case class InternalPubSubError(cause: Throwable) extends Throwable("Internal Java PubSub consumer failed", cause)
+  case class InternalPubSubError(cause: Throwable)
+      extends Throwable("Internal Java PubSub consumer failed", cause)
+      with NoStackTrace
 
   /**
     * Subscribe with manual acknowledgement

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
@@ -78,6 +78,6 @@ private[consumer] object PubsubSubscriber {
     for {
       queue <- Stream.resource(PubsubSubscriber.createSubscriber(projectId, subscription, config))
       next  <- Stream.repeatEval(Sync[F].blocking(queue.take()))
-      msg   <- next.fold(Stream.raiseError(_), Stream.emit(_))
+      msg   <- Stream.fromEither[F](next)
     } yield msg
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,11 +10,11 @@ object Dependencies {
     val http4s         = "0.23.1"
     val log4cats       = "2.1.1"
     val jwt            = "3.18.1"
-    val jsoniter       = "2.9.1"
+    val jsoniter       = "2.10.0"
     val gcp            = "1.114.0"
     val scalatest      = "3.2.9"
     val scalatestPlus  = "3.2.2.0"
-    val testContainers = "0.39.5"
+    val testContainers = "0.39.6"
   }
 
   object Libraries {


### PR DESCRIPTION
- Update jsoniter to 2.10.0, testcontainers to 0.39.6
- Use `Stream.fromEither` instead of manual fold
- Add `NoStackTrace` to `InternalPubSubError`