### PR TITLE
Bump dependencies; Minor tweaks before release

### DIFF
--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumer.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumer.scala
@@ -9,6 +9,8 @@ import com.permutive.pubsub.consumer.grpc.internal.PubsubSubscriber
 import com.permutive.pubsub.consumer.{ConsumerRecord, Model}
 import fs2.Stream
 
+import scala.util.control.NoStackTrace
+
 object PubsubGoogleConsumer {
 
   /**
@@ -16,7 +18,9 @@ object PubsubGoogleConsumer {
     *
     * @param cause the cause of the failure
     */
-  case class InternalPubSubError(cause: Throwable) extends Throwable("Internal Java PubSub consumer failed", cause)
+  case class InternalPubSubError(cause: Throwable)
+      extends Throwable("Internal Java PubSub consumer failed", cause)
+      with NoStackTrace
 
   /**
     * Subscribe with manual acknowledgement

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumer.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumer.scala
@@ -27,7 +27,6 @@ object PubsubGoogleConsumer {
     *
     * The stream fails with an [[InternalPubSubError]] if the underlying Java consumer fails.
     *
-    * @param blocker
     * @param projectId    google cloud project id
     * @param subscription name of the subscription
     * @param errorHandler upon failure to decode, an exception is thrown. Allows acknowledging the message.
@@ -52,7 +51,6 @@ object PubsubGoogleConsumer {
     *
     * The stream fails with an [[InternalPubSubError]] if the underlying Java consumer fails.
     *
-    * @param blocker
     * @param projectId    google cloud project id
     * @param subscription name of the subscription
     * @param errorHandler upon failure to decode, an exception is thrown. Allows acknowledging the message.

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
@@ -78,6 +78,6 @@ private[consumer] object PubsubSubscriber {
     for {
       queue <- Stream.resource(PubsubSubscriber.createSubscriber(projectId, subscription, config))
       next  <- Stream.repeatEval(Sync[F].blocking(queue.take()))
-      msg   <- next.fold(Stream.raiseError(_), Stream.emit(_))
+      msg   <- Stream.fromEither[F](next)
     } yield msg
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.jsuereth"      % "sbt-pgp"                % "2.1.1")
+addSbtPlugin("com.github.sbt"    % "sbt-pgp"                % "2.1.2")
 addSbtPlugin("com.github.gseitz" % "sbt-release"            % "1.0.13")
 addSbtPlugin("com.typesafe"      % "sbt-mima-plugin"        % "0.9.2")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"           % "2.4.3")


### PR DESCRIPTION
- Use `Stream.fromEither` instead of manual fold
- Add `NoStackTrace` to `InternalPubSubError`
- Bump `sbt-pgp` to 2.1.2 (replaces #278 which needed formatting)