### PR TITLE
Avoid thread switch for every message in gRPC consumer

### DIFF
--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
@@ -1,36 +1,31 @@
 package com.permutive.pubsub.consumer.grpc.internal
 
-import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue, TimeUnit}
-
 import cats.effect.kernel.{Resource, Sync}
 import cats.syntax.all._
 import com.google.api.core.ApiService
 import com.google.api.gax.batching.FlowControlSettings
-import com.google.common.util.concurrent.MoreExecutors
 import com.google.cloud.pubsub.v1.{AckReplyConsumer, MessageReceiver, Subscriber}
+import com.google.common.util.concurrent.MoreExecutors
 import com.google.pubsub.v1.{ProjectSubscriptionName, PubsubMessage}
 import com.permutive.pubsub.consumer.grpc.PubsubGoogleConsumer.InternalPubSubError
-import com.permutive.pubsub.consumer.{Model => PublicModel}
 import com.permutive.pubsub.consumer.grpc.PubsubGoogleConsumerConfig
+import com.permutive.pubsub.consumer.{Model => PublicModel}
 import fs2.Stream
 import org.threeten.bp.Duration
 
+import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue, TimeUnit}
+
 private[consumer] object PubsubSubscriber {
 
-  def createSubscriber[F[_]](
+  def createSubscriber[F[_]: Sync](
     projectId: PublicModel.ProjectId,
     subscription: PublicModel.Subscription,
-    config: PubsubGoogleConsumerConfig[F]
-  )(implicit
-    F: Sync[F]
-  ): Resource[F, BlockingQueue[Either[InternalPubSubError, Model.Record[F]]]] =
-    Resource[F, BlockingQueue[Either[InternalPubSubError, Model.Record[F]]]] {
+    config: PubsubGoogleConsumerConfig[F],
+    queue: BlockingQueue[Either[InternalPubSubError, Model.Record[F]]],
+  ): Resource[F, ApiService] =
+    Resource.make(
       Sync[F].delay {
-        val messages = new LinkedBlockingQueue[Either[InternalPubSubError, Model.Record[F]]](config.maxQueueSize)
-        val receiver = new MessageReceiver {
-          override def receiveMessage(message: PubsubMessage, consumer: AckReplyConsumer): Unit =
-            messages.put(Right(Model.Record(message, Sync[F].delay(consumer.ack()), Sync[F].delay(consumer.nack()))))
-        }
+        val receiver         = new PubsubMessageReceiver(queue)
         val subscriptionName = ProjectSubscriptionName.of(projectId.value, subscription.value)
 
         // build subscriber with "normal" settings
@@ -53,21 +48,24 @@ private[consumer] object PubsubSubscriber {
             .getOrElse(builder)
             .build()
 
-        sub.addListener(new PubsubErrorListener(messages), MoreExecutors.directExecutor)
+        sub.addListener(new PubsubErrorListener(queue), MoreExecutors.directExecutor)
 
-        val service = sub.startAsync()
-        val shutdown =
-          F.blocking(
-            service.stopAsync().awaitTerminated(config.awaitTerminatePeriod.toSeconds, TimeUnit.SECONDS)
-          ).handleErrorWith(config.onFailedTerminate)
-
-        (messages, shutdown)
+        sub.startAsync()
       }
-    }
+    )(service =>
+      Sync[F]
+        .blocking(service.stopAsync().awaitTerminated(config.awaitTerminatePeriod.toSeconds, TimeUnit.SECONDS))
+        .handleErrorWith(config.onFailedTerminate)
+    )
 
-  class PubsubErrorListener[R](messages: BlockingQueue[Either[InternalPubSubError, R]]) extends ApiService.Listener {
+  class PubsubMessageReceiver[F[_]: Sync, L](queue: BlockingQueue[Either[L, Model.Record[F]]]) extends MessageReceiver {
+    override def receiveMessage(message: PubsubMessage, consumer: AckReplyConsumer): Unit =
+      queue.put(Right(Model.Record(message, Sync[F].delay(consumer.ack()), Sync[F].delay(consumer.nack()))))
+  }
+
+  class PubsubErrorListener[R](queue: BlockingQueue[Either[InternalPubSubError, R]]) extends ApiService.Listener {
     override def failed(from: ApiService.State, failure: Throwable): Unit =
-      messages.put(Left(InternalPubSubError(failure)))
+      queue.put(Left(InternalPubSubError(failure)))
   }
 
   def subscribe[F[_]: Sync](
@@ -76,8 +74,11 @@ private[consumer] object PubsubSubscriber {
     config: PubsubGoogleConsumerConfig[F],
   ): Stream[F, Model.Record[F]] =
     for {
-      queue <- Stream.resource(PubsubSubscriber.createSubscriber(projectId, subscription, config))
-      next  <- Stream.repeatEval(Sync[F].blocking(queue.take()))
-      msg   <- Stream.fromEither[F](next)
+      queue <- Stream.eval(
+        Sync[F].delay(new LinkedBlockingQueue[Either[InternalPubSubError, Model.Record[F]]](config.maxQueueSize))
+      )
+      _    <- Stream.resource(PubsubSubscriber.createSubscriber(projectId, subscription, config, queue))
+      next <- Stream.repeatEval(Sync[F].blocking(queue.take()))
+      msg  <- Stream.fromEither[F](next)
     } yield msg
 }


### PR DESCRIPTION
Previously we (correctly) used `blocking` to suspend an effect which
_could_ block (taking an element from a `BlockingQueue`, waiting if
necessary). Instead, we now try to take an element (without blocking)
and only if one is not available to we call `blocking` and await an
element.

Also includes a minor refactor of internals to make code a bit more
consistent.