### PR TITLE
Use `Stream.fromQueue*` instead of `Stream.repeatEval(queue.take)`

### DIFF
--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/PubsubSubscriber.scala
@@ -54,14 +54,14 @@ private[http] object PubsubSubscriber {
         source
           .concurrently(
             Stream
-              .repeatEval(ackQ.take)
+              .fromQueueUnterminated(ackQ)
               .groupWithin(config.acknowledgeBatchSize, config.acknowledgeBatchLatency)
               .evalMap(ids => reader.ack(ids.toList).handleErrorWith(errorHandler))
               .onFinalize(Logger[F].debug("[PubSub] Ack queue has exited."))
           )
           .concurrently(
             Stream
-              .repeatEval(nackQ.take)
+              .fromQueueUnterminated(nackQ)
               .groupWithin(config.acknowledgeBatchSize, config.acknowledgeBatchLatency)
               .evalMap(ids => reader.nack(ids.toList).handleErrorWith(errorHandler))
               .onFinalize(Logger[F].debug("[PubSub] Nack queue has exited."))

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/internal/BatchingHttpPublisher.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/internal/BatchingHttpPublisher.scala
@@ -74,7 +74,7 @@ private[http] object BatchingHttpPublisher {
       }
 
     Stream
-      .repeatEval(queue.take)
+      .fromQueueUnterminated(queue)
       .groupWithin(config.batchSize, config.maxLatency)
       .evalMap { asyncRecords =>
         handler(asyncRecords).void.attempt


### PR DESCRIPTION
The `fs2` implementation will be more efficient as it will emit all
elements available in a single chunk.