### PR TITLE
Expose message attributes in `ConsumerRecord`

### DIFF
--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/Model.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/Model.scala
@@ -22,9 +22,10 @@ private[http] object Model {
 
     def toConsumerRecord[A](v: A): ConsumerRecord[F, A] =
       new ConsumerRecord[F, A] {
-        override val value: A      = v
-        override val ack: F[Unit]  = self.ack
-        override val nack: F[Unit] = self.nack
+        override val value: A                        = v
+        override val attributes: Map[String, String] = self.value.attributes
+        override val ack: F[Unit]                    = self.ack
+        override val nack: F[Unit]                   = self.nack
 
         override def extendDeadline(by: FiniteDuration): F[Unit] = self.extendDeadline(by)
       }

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/consumer/ConsumerRecord.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/consumer/ConsumerRecord.scala
@@ -7,6 +7,7 @@ import scala.concurrent.duration.FiniteDuration
 
 trait ConsumerRecord[F[_], A] {
   def value: A
+  def attributes: Map[String, String]
   def ack: F[Unit]
   def nack: F[Unit]
   def extendDeadline(by: FiniteDuration): F[Unit]
@@ -18,17 +19,19 @@ object ConsumerRecord {
 
   abstract private[this] case class RecordImpl[F[_], A](
     value: A,
+    attributes: Map[String, String],
     ack: F[Unit],
     nack: F[Unit],
   ) extends ConsumerRecord[F, A]
 
   def apply[F[_], A](
     value: A,
+    attributes: Map[String, String],
     ack: F[Unit],
     nack: F[Unit],
     extend: FiniteDuration => F[Unit],
   ): ConsumerRecord[F, A] =
-    new RecordImpl(value, ack, nack) {
+    new RecordImpl(value, attributes, ack, nack) {
       final override def extendDeadline(by: FiniteDuration): F[Unit] = extend(by)
     }
 }


### PR DESCRIPTION
Previously `ConsumerRecord` only contained the message data and
discarded any attributes. This PR attaches the attributes in a new field
on `ConsumerRecord`.