### PR TITLE
Emit larger chunks in HTTP and gRPC consumers

### DIFF
--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumer.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumer.scala
@@ -38,15 +38,22 @@ object PubsubGoogleConsumer {
     errorHandler: (PubsubMessage, Throwable, F[Unit], F[Unit]) => F[Unit],
     config: PubsubGoogleConsumerConfig[F]
   ): Stream[F, ConsumerRecord[F, A]] =
-    PubsubSubscriber
-      .subscribe(projectId, subscription, config)
-      .flatMap { case internal.Model.Record(msg, ack, nack) =>
-        MessageDecoder[A].decode(msg.getData.toByteArray) match {
-          case Left(e) => Stream.exec(errorHandler(msg, e, ack, nack))
-          case Right(v) =>
-            Stream.emit(ConsumerRecord(v, msg.getAttributesMap.asScala.toMap, ack, nack, _ => Applicative[F].unit))
-        }
-      }
+    subscribeDecode[F, A, ConsumerRecord[F, A]](
+      projectId,
+      subscription,
+      errorHandler,
+      config,
+      onDecode = (record, value) =>
+        Applicative[F].pure(
+          ConsumerRecord(
+            value,
+            record.value.getAttributesMap.asScala.toMap,
+            record.ack,
+            record.nack,
+            _ => Applicative[F].unit
+          )
+        ),
+    )
 
   /**
     * Subscribe with automatic acknowledgement
@@ -63,14 +70,13 @@ object PubsubGoogleConsumer {
     errorHandler: (PubsubMessage, Throwable, F[Unit], F[Unit]) => F[Unit],
     config: PubsubGoogleConsumerConfig[F]
   ): Stream[F, A] =
-    PubsubSubscriber
-      .subscribe(projectId, subscription, config)
-      .flatMap { case internal.Model.Record(msg, ack, nack) =>
-        MessageDecoder[A].decode(msg.getData.toByteArray) match {
-          case Left(e)  => Stream.exec(errorHandler(msg, e, ack, nack))
-          case Right(v) => Stream.eval(ack >> v.pure)
-        }
-      }
+    subscribeDecode[F, A, A](
+      projectId,
+      subscription,
+      errorHandler,
+      config,
+      onDecode = (record, value) => record.ack.as(value),
+    )
 
   /**
     * Subscribe to the raw stream, receiving the the message as retrieved from PubSub
@@ -86,5 +92,21 @@ object PubsubGoogleConsumer {
       .subscribe(projectId, subscription, config)
       .map(msg =>
         ConsumerRecord(msg.value, msg.value.getAttributesMap.asScala.toMap, msg.ack, msg.nack, _ => Applicative[F].unit)
+      )
+
+  private def subscribeDecode[F[_]: Sync, A: MessageDecoder, B](
+    projectId: Model.ProjectId,
+    subscription: Model.Subscription,
+    errorHandler: (PubsubMessage, Throwable, F[Unit], F[Unit]) => F[Unit],
+    config: PubsubGoogleConsumerConfig[F],
+    onDecode: (internal.Model.Record[F], A) => F[B],
+  ): Stream[F, B] =
+    PubsubSubscriber
+      .subscribe(projectId, subscription, config)
+      .flatMap(record =>
+        MessageDecoder[A].decode(record.value.getData.toByteArray) match {
+          case Left(e)  => Stream.exec(errorHandler(record.value, e, record.ack, record.ack))
+          case Right(v) => Stream.eval(onDecode(record, v))
+        }
       )
 }

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
@@ -11,9 +11,11 @@ import com.google.pubsub.v1.{ProjectSubscriptionName, PubsubMessage}
 import com.permutive.pubsub.consumer.grpc.PubsubGoogleConsumer.InternalPubSubError
 import com.permutive.pubsub.consumer.grpc.PubsubGoogleConsumerConfig
 import com.permutive.pubsub.consumer.{Model => PublicModel}
-import fs2.Stream
+import fs2.{Chunk, Stream}
 import org.threeten.bp.Duration
 
+import java.util
+import collection.JavaConverters._
 import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue, TimeUnit}
 
 private[consumer] object PubsubSubscriber {
@@ -69,11 +71,14 @@ private[consumer] object PubsubSubscriber {
       queue.put(Left(InternalPubSubError(failure)))
   }
 
-  def takeNextElement[F[_]: Sync, A](messages: BlockingQueue[A]): F[A] =
+  def takeNextElements[F[_]: Sync, A](messages: BlockingQueue[A]): F[Chunk[A]] =
     for {
-      nextOpt <- Sync[F].delay(Option(messages.poll())) // `poll` is non-blocking, returning `null` if queue is empty
-      next    <- nextOpt.fold(Sync[F].blocking(messages.take()))(Applicative[F].pure) // `take` can wait for an element
-    } yield next
+      nextOpt  <- Sync[F].delay(Option(messages.poll())) // `poll` is non-blocking, returning `null` if queue is empty
+      next     <- nextOpt.fold(Sync[F].blocking(messages.take()))(Applicative[F].pure) // `take` can wait for an element
+      elements <- Sync[F].delay(new util.ArrayList[A])
+      _        <- Sync[F].delay(elements.add(next))
+      _        <- Sync[F].delay(messages.drainTo(elements))
+    } yield Chunk.buffer(elements.asScala)
 
   def subscribe[F[_]: Sync](
     projectId: PublicModel.ProjectId,
@@ -84,8 +89,9 @@ private[consumer] object PubsubSubscriber {
       queue <- Stream.eval(
         Sync[F].delay(new LinkedBlockingQueue[Either[InternalPubSubError, Model.Record[F]]](config.maxQueueSize))
       )
-      _    <- Stream.resource(PubsubSubscriber.createSubscriber(projectId, subscription, config, queue))
-      next <- Stream.repeatEval(takeNextElement(queue))
-      msg  <- Stream.fromEither[F](next)
+      _     <- Stream.resource(PubsubSubscriber.createSubscriber(projectId, subscription, config, queue))
+      taken <- Stream.repeatEval(takeNextElements(queue))
+      // Only retains the first error (if there are multiple), but that is OK, the stream is failing anyway...
+      msg <- Stream.fromEither[F](taken.sequence).unchunks
     } yield msg
 }

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubHttpConsumer.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubHttpConsumer.scala
@@ -1,10 +1,12 @@
 package com.permutive.pubsub.consumer.http
 
+import cats.Applicative
 import cats.effect.kernel.Async
 import cats.syntax.all._
 import com.permutive.pubsub.consumer.ConsumerRecord
 import com.permutive.pubsub.consumer.Model.{ProjectId, Subscription}
 import com.permutive.pubsub.consumer.decoder.MessageDecoder
+import com.permutive.pubsub.consumer.http.internal.Model.InternalRecord
 import com.permutive.pubsub.consumer.http.internal.PubsubSubscriber
 import fs2.Stream
 import org.typelevel.log4cats.Logger
@@ -40,14 +42,16 @@ object PubsubHttpConsumer {
     errorHandler: (PubsubMessage, Throwable, F[Unit], F[Unit]) => F[Unit],
     httpClientRetryPolicy: RetryPolicy[F] = recklesslyRetryPolicy[F]
   ): Stream[F, ConsumerRecord[F, A]] =
-    PubsubSubscriber
-      .subscribe(projectId, subscription, serviceAccountPath, config, httpClient, httpClientRetryPolicy)
-      .flatMap { record =>
-        MessageDecoder[A].decode(Base64.getDecoder.decode(record.value.data.getBytes)) match {
-          case Left(e)  => Stream.exec(errorHandler(record.value, e, record.ack, record.nack))
-          case Right(v) => Stream.emit(record.toConsumerRecord(v))
-        }
-      }
+    subscribeDecode[F, A, ConsumerRecord[F, A]](
+      projectId,
+      subscription,
+      serviceAccountPath,
+      config,
+      httpClient,
+      errorHandler,
+      httpClientRetryPolicy,
+      onDecode = (record, value) => Applicative[F].pure(record.toConsumerRecord(value)),
+    )
 
   /**
     * Subscribe with automatic acknowledgement
@@ -72,14 +76,16 @@ object PubsubHttpConsumer {
     errorHandler: (PubsubMessage, Throwable, F[Unit], F[Unit]) => F[Unit],
     httpClientRetryPolicy: RetryPolicy[F] = recklesslyRetryPolicy[F]
   ): Stream[F, A] =
-    PubsubSubscriber
-      .subscribe(projectId, subscription, serviceAccountPath, config, httpClient, httpClientRetryPolicy)
-      .flatMap { record =>
-        MessageDecoder[A].decode(Base64.getDecoder.decode(record.value.data.getBytes)) match {
-          case Left(e)  => Stream.exec(errorHandler(record.value, e, record.ack, record.nack))
-          case Right(v) => Stream.eval(record.ack >> v.pure)
-        }
-      }
+    subscribeDecode[F, A, A](
+      projectId,
+      subscription,
+      serviceAccountPath,
+      config,
+      httpClient,
+      errorHandler,
+      httpClientRetryPolicy,
+      onDecode = (record, value) => record.ack.as(value),
+    )
 
   /**
     * Subscribe to the raw stream, receiving the the message as retrieved from PubSub
@@ -112,4 +118,23 @@ object PubsubHttpConsumer {
    */
   def recklesslyRetryPolicy[F[_]]: RetryPolicy[F] =
     RetryPolicy(exponentialBackoff(maxWait = 5.seconds, maxRetry = 3), (_, result) => recklesslyRetriable(result))
+
+  private def subscribeDecode[F[_]: Async: Logger, A: MessageDecoder, B](
+    projectId: ProjectId,
+    subscription: Subscription,
+    serviceAccountPath: Option[String],
+    config: PubsubHttpConsumerConfig[F],
+    httpClient: Client[F],
+    errorHandler: (PubsubMessage, Throwable, F[Unit], F[Unit]) => F[Unit],
+    httpClientRetryPolicy: RetryPolicy[F],
+    onDecode: (InternalRecord[F], A) => F[B],
+  ): Stream[F, B] =
+    PubsubSubscriber
+      .subscribe(projectId, subscription, serviceAccountPath, config, httpClient, httpClientRetryPolicy)
+      .flatMap(record =>
+        MessageDecoder[A].decode(Base64.getDecoder.decode(record.value.data.getBytes)) match {
+          case Left(e)  => Stream.exec(errorHandler(record.value, e, record.ack, record.nack))
+          case Right(v) => Stream.eval(onDecode(record, v))
+        }
+      )
 }

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/PingPongSpec.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/PingPongSpec.scala
@@ -6,7 +6,8 @@ import com.google.cloud.pubsub.v1.{SubscriptionAdminClient, TopicAdminClient}
 import com.google.pubsub.v1.{ProjectSubscriptionName, TopicName}
 import com.permutive.pubsub.consumer.ConsumerRecord
 import com.permutive.pubsub.consumer.http.Example.ValueHolder
-import com.permutive.pubsub.producer.PubsubProducer
+import com.permutive.pubsub.producer.Model.SimpleRecord
+import com.permutive.pubsub.producer.{Model, PubsubProducer}
 import fs2.Stream
 import org.http4s.client.Client
 import org.scalatest.BeforeAndAfterEach
@@ -87,6 +88,41 @@ class PingPongSpec extends PubSubSpec with BeforeAndAfterEach {
       _                <- Stream.sleep[IO](10.seconds).concurrently(consumeAndAck(client, ref))
       elementsReceived <- Stream.eval(ref.get)
     } yield elementsReceived should ===(1))
+      .as(ExitCode.Success)
+      .compile
+      .drain
+      .unsafeRunSync()
+  }
+
+  private def consumeExpectingChunksize(
+    client: Client[IO],
+    elementsReceived: Ref[IO, Int],
+    chunkSizeExpected: Int,
+  ): Stream[IO, ConsumerRecord[IO, ValueHolder]] =
+    consumer(client).chunks
+      .evalTap(c =>
+        IO.raiseError(new RuntimeException(s"Chunks were of the wrong size, received ${c.size}"))
+          .unlessA(c.size == chunkSizeExpected)
+      )
+      .unchunks
+      .evalTap(_ => elementsReceived.update(_ + 1))
+      .evalTap(_.ack)
+
+  it should "preserve chunksize in the underlying stream" in {
+    val messagesToSend = 5
+
+    (for {
+      // We will sleep for 10 seconds, which means if the message is not acked it will be redelivered before end of test
+      (client, producer) <- Stream.resource(setup(ackDeadlineSeconds = 5))
+      _ <- Stream.eval(
+        // This must be produced using `produceMany` otherwise the returned elements are in individual chunks
+        producer.produceMany(List.fill[Model.Record[ValueHolder]](messagesToSend)(SimpleRecord(ValueHolder("ping"))))
+      )
+      ref <- Stream.eval(Ref.of[IO, Int](0))
+      // Wait 10 seconds whilst we run the consumer to check we have received all elements in a single chunk
+      _                <- Stream.sleep[IO](10.seconds).concurrently(consumeExpectingChunksize(client, ref, messagesToSend))
+      elementsReceived <- Stream.eval(ref.get)
+    } yield elementsReceived should ===(messagesToSend))
       .as(ExitCode.Success)
       .compile
       .drain

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/PubSubSpec.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/PubSubSpec.scala
@@ -159,20 +159,18 @@ trait PubSubSpec extends AnyFlatSpec with ForAllTestContainer with Matchers with
     project: String = project,
     subscription: String = subscription,
   ): Stream[IO, ConsumerRecord[IO, ValueHolder]] =
-    for {
-      out <- PubsubHttpConsumer.subscribe[IO, ValueHolder](
-        Model.ProjectId(project),
-        Model.Subscription(subscription),
-        Some("/path/to/service/account"),
-        PubsubHttpConsumerConfig(
-          host = container.host,
-          port = container.mappedPort(8085),
-          isEmulator = true
-        ),
-        client,
-        (msg, err, ack, _) => IO.println(s"Msg $msg got error $err") >> ack
-      )
-    } yield out
+    PubsubHttpConsumer.subscribe[IO, ValueHolder](
+      Model.ProjectId(project),
+      Model.Subscription(subscription),
+      Some("/path/to/service/account"),
+      PubsubHttpConsumerConfig(
+        host = container.host,
+        port = container.mappedPort(8085),
+        isEmulator = true
+      ),
+      client,
+      (msg, err, ack, _) => IO.println(s"Msg $msg got error $err") >> ack
+    )
 
   def updateEnv(name: String, value: String): Unit = {
     val env   = System.getenv


### PR DESCRIPTION
CE3 port/tweak of #329.

There are two subtle user-affecting changes as a result of this:
 1) In both consumer variants if any message in a chunk fails to
     decode the `errorHandler` is invoked _before_ any successfully
     decoded messages in the chunk are emitted downstream; even
     if the message which failed to decode comes after the successful
     ones.
2) In the gRPC variant alone the stream may fail _sooner_ if an internal
     failure occurs in the Java library. This should not matter at all.
    